### PR TITLE
Add ME-South-1 and AF-South-1 regions

### DIFF
--- a/scripts/all_layers.sh
+++ b/scripts/all_layers.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+# Common info used by list_layers.sh and publish_layers.sh
+
+AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
+AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1 me-south-1 af-south-1)

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -8,6 +8,7 @@
 # Lists most recent layers ARNs across regions to STDOUT
 # Optionals args: [layer-name] [region]
 
+# Source the common list of layers and regions
 source scripts/all_layers.sh
 
 # Check region arg

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -8,8 +8,7 @@
 # Lists most recent layers ARNs across regions to STDOUT
 # Optionals args: [layer-name] [region]
 
-LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
+source scripts/all_layers.sh
 
 # Check region arg
 if [ -z "$2" ]; then
@@ -29,11 +28,11 @@ fi
 # Check region arg
 if [ -z "$1" ]; then
     >&2 echo "Layer parameter not specified, running for all layers "
-    LAYERS=("${LAYER_NAMES[@]}")
+    LAYERS=("${AVAILABLE_LAYER_NAMES[@]}")
 else
     >&2 echo "Layer parameter specified: $1"
-    if [[ ! " ${LAYER_NAMES[@]} " =~ " ${1} " ]]; then
-        >&2 echo "Could not find $1 in layers: ${LAYER_NAMES[@]}"
+    if [[ ! " ${AVAILABLE_LAYER_NAMES[@]} " =~ " ${1} " ]]; then
+        >&2 echo "Could not find $1 in layers: ${AVAILABLE_LAYER_NAMES[@]}"
         >&2 echo ""
         >&2 echo "EXITING SCRIPT."
         return 1

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -16,7 +16,7 @@ trap "pkill -P $$; exit 1;" INT
 PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
 LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
 AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
+AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1 me-south-1 af-south-1)
 
 # Check that the layer files exist
 for layer_file in "${LAYER_PATHS[@]}"

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -16,6 +16,7 @@ trap "pkill -P $$; exit 1;" INT
 PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
 LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
 
+# Source the common list of layers and regions
 source scripts/all_layers.sh
 
 # Check that the layer files exist

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -15,8 +15,8 @@ trap "pkill -P $$; exit 1;" INT
 
 PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
 LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
-AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1 me-south-1 af-south-1)
+
+source scripts/all_layers.sh
 
 # Check that the layer files exist
 for layer_file in "${LAYER_PATHS[@]}"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds the ME-South-1 region and AF-South-1 region. ME-South-1 was requested in #64 , and I noticed AF-South-1 was missing.

### Motivation

This allows customers in me-south-1 and af-south-1 to deploy our lambda layer.

### Testing Guidelines



### Additional Notes



### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
