### PR TITLE
Update package version number to 2.20.0 to correspond with Release v20

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,6 +1,6 @@
 # The minor version corresponds to the Lambda layer version.
 # E.g.,, version 0.5.0 gets packaged into layer version 5.
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 
 
 import os


### PR DESCRIPTION
### What does this PR do?

Updates package version number to `2.20.0` to correspond with [Release v20](https://github.com/DataDog/datadog-lambda-python/releases/tag/v20)

### Motivation

I noticed today that `pipenv` was suddenly encountering errors trying to resolve dependencies for this library:
```
There are incompatible versions in the resolved dependencies:
  datadog==0.32.0 (from -r /tmp/pipenv1ww874dorequirements/pipenv-lh25x49g-constraints.txt (line 7))
  datadog==0.38.0 (from datadog-lambda==2.19.0->-r /tmp/pipenv1ww874dorequirements/pipenv-lh25x49g-constraints.txt (line 4))
```

This strange behavior seemed to suggest that package version `2.19.0` had changed in [PyPi](https://pypi.org/project/datadog-lambda/) from the last time I had run `pipenv` (and tl;dr, this appears to be exactly what happened).

I found that a [v20 Release](https://github.com/DataDog/datadog-lambda-python/releases/tag/v20) was published today which [updated the `datadog` dependency in `datadog-lambda` from `0.32.0` to `0.38.0`](https://github.com/DataDog/datadog-lambda-python/compare/v19...v20#diff-2eeaed663bd0d25b7e608891384b7298R32), which aligned with the behavior I was seeing.  Upon checking [PyPi](https://pypi.org/project/datadog-lambda/), there did not seem to be a new release: 
![image](https://user-images.githubusercontent.com/31746850/91369232-4b91fe80-e7d9-11ea-9a4f-d31500c21980.png)

However, I found that a new py3 wheel for `2.19.0` was uploaded earlier today, which again corresponds to the timing of the [v20 Release](https://github.com/DataDog/datadog-lambda-python/releases/tag/v20):
![image](https://user-images.githubusercontent.com/31746850/91369313-77ad7f80-e7d9-11ea-8530-567b79a472f3.png)

This seems to explain the behavior I was seeing, where `pipenv` when resolving dependencies yesterday (on a py3 project) saw this library's `2.19.0` package requiring `datadog==0.32.0`, to today it requiring `datadog==0.38.0`.

As far as this fix, I went and looked at previous releases and noted that they always included an update to the package version number ([like here, for v19](https://github.com/DataDog/datadog-lambda-python/compare/v18...v19#diff-512c23199ba0e54b271ca0d43c143d6eR3)).

### Testing Guidelines

N/A for this change - but just in case, the test suite still passes locally: 
![image](https://user-images.githubusercontent.com/31746850/91370073-62d1eb80-e7db-11ea-8fd3-1b623b2ca2f0.png)

### Additional Notes

I imagine additional steps will need to be taken post-merge to [publish](https://github.com/DataDog/datadog-lambda-python/blob/master/scripts/pypi.sh) version `2.20.0` to PyPi, and revert the `2.19.0` py3 wheel to the correct one.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
