### PR TITLE
Enable compressed payloads on ThreadStats object

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -41,7 +41,7 @@ lambda_stats = None
 if should_use_extension:
     lambda_stats = StatsDWrapper()
 else:
-    lambda_stats = ThreadStats()
+    lambda_stats = ThreadStats(compress_payload=True)
     lambda_stats.start()
 
 


### PR DESCRIPTION
### What does this PR do?

Enable submitting compressed payloads to the Datadog API.

### Motivation

We use lambdas to scrape metrics which we can't easily collect by other means. These metric lambdas can collect large numbers of metrics quickly, and occasionally submit too many metrics within the same flush interval for the Datadog API to handle. This is similar to the issue in DataDog/datadogpy#465. The solution implemented to fix that issue was compression of payloads submitted to the DD API.

### Testing Guidelines

`./scripts/run_tests.sh`

### Additional Notes

n/a

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
