### PR TITLE
Tag enhanced metrics with datadog lambda library version

### DIFF
--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -4,7 +4,6 @@ from platform import python_version_tuple
 
 from datadog_lambda import __version__
 from datadog_lambda.cold_start import get_cold_start_tag
-from ddtrace import __version__ as ddtrace_version
 
 
 def _format_dd_lambda_layer_tag():

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -81,7 +81,7 @@ def get_runtime_tag():
 def get_library_version_tag():
     """Get datadog lambda library tag
     """
-    return "datadog_lambda:{}".format(__version__)
+    return "datadog_lambda:v{}".format(__version__)
 
 
 def get_enhanced_metrics_tags(lambda_context):

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -4,6 +4,7 @@ from platform import python_version_tuple
 
 from datadog_lambda import __version__
 from datadog_lambda.cold_start import get_cold_start_tag
+from ddtrace import __version__ as ddtrace_version
 
 
 def _format_dd_lambda_layer_tag():
@@ -77,6 +78,11 @@ def get_runtime_tag():
         major=major_version, minor=minor_version
     )
 
+def get_library_version_tag():
+    """Get datadog lambda library tag
+    """
+    return "datadog_lambda:{}".format(__version__)
+
 
 def get_enhanced_metrics_tags(lambda_context):
     """Get the list of tags to apply to enhanced metrics
@@ -85,6 +91,7 @@ def get_enhanced_metrics_tags(lambda_context):
         get_cold_start_tag(),
         "memorysize:{}".format(lambda_context.memory_limit_in_mb),
         get_runtime_tag(),
+        get_library_version_tag()
     ]
 
 

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -77,6 +77,7 @@ def get_runtime_tag():
         major=major_version, minor=minor_version
     )
 
+
 def get_library_version_tag():
     """Get datadog lambda library tag
     """
@@ -90,7 +91,7 @@ def get_enhanced_metrics_tags(lambda_context):
         get_cold_start_tag(),
         "memorysize:{}".format(lambda_context.memory_limit_in_mb),
         get_runtime_tag(),
-        get_library_version_tag()
+        get_library_version_tag(),
     ]
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -68,6 +68,13 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_write_metric_point_to_stdout = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch("datadog_lambda.tags.get_library_version_tag")
+        self.mock_format_dd_lambda_layer_tag = patcher.start()
+        # Mock the layer version so we don't have to update tests on every version bump
+        self.mock_format_dd_lambda_layer_tag.return_value = (
+            "datadog_lambda:v6.6.6"
+        )
+
         patcher = patch("datadog_lambda.tags._format_dd_lambda_layer_tag")
         self.mock_format_dd_lambda_layer_tag = patcher.start()
         # Mock the layer version so we don't have to update tests on every version bump
@@ -146,6 +153,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -176,6 +184,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -191,6 +200,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -226,6 +236,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -241,6 +252,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:false",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -274,6 +286,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,
@@ -307,6 +320,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "cold_start:true",
                         "memorysize:256",
                         "runtime:python2.7",
+                        "datadog_lambda:v6.6.6",
                         "dd_lambda_layer:datadog-python27_0.1.0",
                     ],
                     timestamp=None,

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -71,9 +71,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         patcher = patch("datadog_lambda.tags.get_library_version_tag")
         self.mock_format_dd_lambda_layer_tag = patcher.start()
         # Mock the layer version so we don't have to update tests on every version bump
-        self.mock_format_dd_lambda_layer_tag.return_value = (
-            "datadog_lambda:v6.6.6"
-        )
+        self.mock_format_dd_lambda_layer_tag.return_value = "datadog_lambda:v6.6.6"
 
         patcher = patch("datadog_lambda.tags._format_dd_lambda_layer_tag")
         self.mock_format_dd_lambda_layer_tag = patcher.start()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds `datadog_lambda:v${version}` tag to enhanced metrics

<!--- A brief description of the change being made with this pull request. --->

### Motivation
This will allow us to aggregate the library versions used by our customers.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [X] This PR passes the integration tests (ask a Datadog member to run the tests)
