### PR TITLE
Add support for API Key in SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If `DD_FLUSH_TO_LOG` is set to `false` (not recommended), the Datadog API Key mu
 - DD_API_KEY - the Datadog API Key in plain-text, NOT recommended
 - DD_KMS_API_KEY - the KMS-encrypted API Key, requires the `kms:Decrypt` permission
 - DD_API_KEY_SECRET_ARN - the Secret ARN to fetch API Key from the Secrets Manager, requires the `secretsmanager:GetSecretValue` permission (and `kms:Decrypt` if using a customer managed CMK)
+- DD_API_KEY_SSM_NAME - the Parameter Name to fetch API Key from the Systems Manager Parameter Store, requires the `ssm:GetParameter` permission (and `kms:Decrypt` if using a SecureString with a customer managed CMK)
 
 You can also supply or override the API key at runtime (not recommended):
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds option to fetch API Key from AWS SSM.

### Motivation

<!--- What inspired you to submit this pull request? --->
I store my DD API Key as a SecureString in AWS SSM. Fetching from SSM is currently supported directly in the logs forwarder Lambda function, but it would be cleaner to support at this level so any future usage of this library has the functionality out-of-the-box.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->
Related MR for downstream lambda function (before refactor to use this library): https://github.com/DataDog/datadog-serverless-functions/pull/196

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
