### PR TITLE
Sign layer using AWS Signer before publishing

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -70,7 +70,7 @@ echo "Building layers..."
 
 echo
 echo "Signing layers..."
-./scripts/sign_layers.sh us-east-1
+./scripts/sign_layers.sh prod
 
 echo
 echo "Publishing layers to AWS regions..."

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -57,22 +57,26 @@ then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
 fi
 
-echo ""
+echo
 echo "Replacing __version__ in ./datadog_lambda/__init__.py"
-echo ""
+echo
 sed -i "" -E "s/\"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\"/\"$NEW_VERSION\"/" ./datadog_lambda/__init__.py
 
 git commit ./datadog_lambda/__init__.py -m "Update module version to ${NEW_VERSION}"
 
-echo ""
+echo
 echo "Building layers..."
 ./scripts/build_layers.sh
 
-echo ""
+echo
+echo "Signing layers..."
+./scripts/sign_layers.sh us-east-1
+
+echo
 echo "Publishing layers to AWS regions..."
 ./scripts/publish_layers.sh
 
-echo ""
+echo
 echo 'Pushing updates to github'
 MINOR_VERSION=$(echo $NEW_VERSION | cut -d '.' -f 2)
 git push origin master
@@ -89,14 +93,14 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
     [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
 fi
-echo ""
+echo
 echo "Publishing to https://pypi.org/project/datadog-lambda/"
 ./scripts/pypi.sh
 
-echo ""
+echo
 echo "Now create a new release with the tag v${MINOR_VERSION} created"
 echo "https://github.com/DataDog/datadog-lambda-python/releases/new"
-echo ""
+echo
 echo "Then publish a new serverless-plugin-datadog version with the new layer versions!"
-echo ""
+echo
 

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -2,5 +2,5 @@
 set -e
 
 ./scripts/build_layers.sh
-./scripts/sign_layers.sh sa-east-1
+./scripts/sign_layers.sh sandbox
 ./scripts/publish_layers.sh sa-east-1

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+./scripts/build_layers.sh
+./scripts/sign_layers.sh sa-east-1
+./scripts/publish_layers.sh sa-east-1

--- a/scripts/publish_staging.sh
+++ b/scripts/publish_staging.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-./scripts/build_layers.sh
-./scripts/publish_layers.sh us-east-1

--- a/scripts/sign_layers.sh
+++ b/scripts/sign_layers.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+set -e
+
+LAYER_DIR=".layers"
+LAYER_FILES=(
+    "datadog_lambda_py2.5.zip"
+    "datadog_lambda_py3.6.zip"
+    "datadog_lambda_py3.7.zip"
+    "datadog_lambda_py3.8.zip"
+)
+S3_BUCKET_NAME="dd-lambda-signing-bucket"
+SIGNING_PROFILE_NAME="DatadogLambdaSigningProfile"
+
+# Check region arg
+VALID_REGIONS=("us-east-1" "sa-east-1")
+if [ -z "$1" ]; then
+    echo "ERROR: You must pass a region parameter to sign the layers"
+    exit 1
+else
+    if [[ ! "${VALID_REGIONS[@]}" =~ $1 ]]; then
+        echo "ERROR: The region parameter was invalid. Please choose us-east-1 or sa-east-1."
+        exit 1
+    fi
+    REGION=$1
+fi
+
+for LAYER_FILE in "${LAYER_FILES[@]}"
+do
+    echo 
+    echo "${LAYER_FILE}"
+    echo "-------------------------"
+
+    LAYER_LOCAL_PATH="${LAYER_DIR}/${LAYER_FILE}"
+
+    # Upload the layer to S3 for signing
+    echo "Uploading layer to S3 for signing..."
+    UUID=$(uuidgen)
+    S3_UNSIGNED_ZIP_KEY="${UUID}.zip"
+    S3_UNSIGNED_ZIP_URI="s3://${S3_BUCKET_NAME}/${S3_UNSIGNED_ZIP_KEY}"
+    aws s3 cp $LAYER_LOCAL_PATH $S3_UNSIGNED_ZIP_URI
+
+    # Start a signing job
+    echo "Starting the signing job..."
+    SIGNING_JOB_ID=$(aws signer start-signing-job \
+        --source "s3={bucketName=${S3_BUCKET_NAME},key=${S3_UNSIGNED_ZIP_KEY},version=null}" \
+        --destination "s3={bucketName=${S3_BUCKET_NAME}}" \
+        --profile-name $SIGNING_PROFILE_NAME \
+        --region $REGION \
+        | jq -r '.jobId'\
+    )
+
+    # Wait for the signing job to complete
+    echo "Waiting for the signing job to complete..."
+    SECONDS_WAITED_SO_FAR=0
+    while :
+    do
+        sleep 3
+        SECONDS_WAITED_SO_FAR=$((SECONDS_WAITED_SO_FAR + 3))
+        
+        SIGNING_JOB_DESCRIPTION=$(aws signer describe-signing-job \
+            --job-id $SIGNING_JOB_ID \
+            --region $REGION\
+        )
+        SIGNING_JOB_STATUS=$(echo $SIGNING_JOB_DESCRIPTION | jq -r '.status')
+        SIGNING_JOB_STATUS_REASON=$(echo $SIGNING_JOB_DESCRIPTION | jq -r '.statusReason')
+
+        if [ $SIGNING_JOB_STATUS = "Succeeded" ]; then
+            echo "Signing job succeeded!"
+            break
+        fi
+
+        if [ $SIGNING_JOB_STATUS = "Failed" ]; then
+            echo "ERROR: Signing job failed"
+            echo $SIGNING_JOB_STATUS_REASON
+            exit 1
+        fi
+
+        if [ $SECONDS_WAITED_SO_FAR -ge 60 ]; then
+            echo "ERROR: Timed out waiting for the signing job to complete"
+            exit 1
+        fi
+
+        echo "Signing job still in progress..."
+    done
+
+    # Download the signed ZIP, overwriting the original ZIP
+    echo "Replacing the local layer with the signed layer from S3..."
+    S3_SIGNED_ZIP_KEY="${SIGNING_JOB_ID}.zip"
+    S3_SIGNED_ZIP_URI="s3://${S3_BUCKET_NAME}/${S3_SIGNED_ZIP_KEY}"
+    aws s3 cp $S3_SIGNED_ZIP_URI $LAYER_LOCAL_PATH
+
+    # Delete the signed and unsigned ZIPs in S3
+    echo "Cleaning up the S3 bucket..."
+    aws s3api delete-object --bucket $S3_BUCKET_NAME --key $S3_UNSIGNED_ZIP_KEY
+    aws s3api delete-object --bucket $S3_BUCKET_NAME --key $S3_SIGNED_ZIP_KEY
+done
+
+echo
+echo "Successfully signed all layers!"

--- a/scripts/sign_layers.sh
+++ b/scripts/sign_layers.sh
@@ -9,25 +9,30 @@ set -e
 
 LAYER_DIR=".layers"
 LAYER_FILES=(
-    "datadog_lambda_py2.5.zip"
+    "datadog_lambda_py2.7.zip"
     "datadog_lambda_py3.6.zip"
     "datadog_lambda_py3.7.zip"
     "datadog_lambda_py3.8.zip"
 )
-S3_BUCKET_NAME="dd-lambda-signing-bucket"
 SIGNING_PROFILE_NAME="DatadogLambdaSigningProfile"
 
-# Check region arg
-VALID_REGIONS=("us-east-1" "sa-east-1")
+# Check account parameter
+VALID_ACCOUNTS=("sandbox" "prod")
 if [ -z "$1" ]; then
-    echo "ERROR: You must pass a region parameter to sign the layers"
+    echo "ERROR: You must pass an account parameter to sign the layers"
     exit 1
-else
-    if [[ ! "${VALID_REGIONS[@]}" =~ $1 ]]; then
-        echo "ERROR: The region parameter was invalid. Please choose us-east-1 or sa-east-1."
-        exit 1
-    fi
-    REGION=$1
+fi
+if [[ ! "${VALID_ACCOUNTS[@]}" =~ $1 ]]; then
+    echo "ERROR: The account parameter was invalid. Please choose sandbox or prod."
+    exit 1
+fi
+if [ "$1" = "sandbox" ]; then
+    REGION="sa-east-1"
+    S3_BUCKET_NAME="dd-lambda-signing-bucket-sandbox"
+fi
+if [ "$1" = "prod" ]; then
+    REGION="us-east-1"
+    S3_BUCKET_NAME="dd-lambda-signing-bucket"
 fi
 
 for LAYER_FILE in "${LAYER_FILES[@]}"


### PR DESCRIPTION
### What does this PR do?

- Add a `sign_layers` script which uploads built layers to S3, uses AWS Signer to sign them, and then downloads the signed layers back to the developer's machine, replacing the unsigned layers.
- Replace the `publish_staging` script with `publish_sandbox`, and publish to the `sa-east-1` region to reflect our current practices.
- Update the `publish_sandbox` and `publish_prod` scripts to call `sign_layers` before `publish_layers`.

### Motivation

We want to support the new [Code Signing for Lambda](https://aws.amazon.com/blogs/aws/new-code-signing-a-trust-and-integrity-control-for-aws-lambda/) feature. This will allow customers to use the layer with functions that are configured to require signed code.

### Testing Guidelines

Tested in the sandbox account. I have also tested the signing process in the prod account.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
