### PR TITLE
[BUGFIX] Fix how we look up the client context

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -99,8 +99,8 @@ def extract_context_from_lambda_context(lambda_context):
     """
     client_context = lambda_context.client_context
 
-    if client_context and "custom" in client_context:
-        dd_data = client_context.get("custom", {}).get("_datadog", {})
+    if client_context and client_context.custom:
+        dd_data = client_context.custom.get("_datadog", {})
         trace_id = dd_data.get(TraceHeader.TRACE_ID)
         parent_id = dd_data.get(TraceHeader.PARENT_ID)
         sampling_priority = dd_data.get(TraceHeader.SAMPLING_PRIORITY)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -21,9 +21,11 @@ from datadog_lambda.tracing import (
 
 function_arn = "arn:aws:lambda:us-west-1:123457598159:function:python-layer-test"
 
+
 class ClientContext(object):
     def __init__(self, custom=None):
         self.custom = custom
+
 
 def get_mock_context(
     aws_request_id="request-id-1",

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -21,20 +21,23 @@ from datadog_lambda.tracing import (
 
 function_arn = "arn:aws:lambda:us-west-1:123457598159:function:python-layer-test"
 
+class ClientContext(object):
+    def __init__(self, custom=None):
+        self.custom = custom
 
 def get_mock_context(
     aws_request_id="request-id-1",
     memory_limit_in_mb="256",
     invoked_function_arn=function_arn,
     function_version="1",
-    client_context={},
+    custom=None,
 ):
     lambda_context = MagicMock()
     lambda_context.aws_request_id = aws_request_id
     lambda_context.memory_limit_in_mb = memory_limit_in_mb
     lambda_context.invoked_function_arn = invoked_function_arn
     lambda_context.function_version = function_version
-    lambda_context.client_context = client_context
+    lambda_context.client_context = ClientContext(custom)
     return lambda_context
 
 
@@ -205,13 +208,11 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
 
     def test_with_client_context_datadog_trace_data(self):
         lambda_ctx = get_mock_context(
-            client_context={
-                "custom": {
-                    "_datadog": {
-                        TraceHeader.TRACE_ID: "666",
-                        TraceHeader.PARENT_ID: "777",
-                        TraceHeader.SAMPLING_PRIORITY: "1",
-                    }
+            custom={
+                "_datadog": {
+                    TraceHeader.TRACE_ID: "666",
+                    TraceHeader.PARENT_ID: "777",
+                    TraceHeader.SAMPLING_PRIORITY: "1",
                 }
             }
         )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

While manually testing my changes for distribuited tracing I found this error - `TypeError: argument of type 'ClientContext' is not iterable` 

This PR modifies how we access the `custom` attribute in the `client_context` object.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
