### PR TITLE
Get status code from AWS Chalice response

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -207,7 +207,9 @@ def extract_http_status_code_tag(trigger_tags, response):
     if response is None:
         # Return a 502 status if no response is found
         status_code = "502"
-    elif response.get("statusCode"):
+    elif hasattr(response, "get"):
         status_code = response.get("statusCode")
+    elif hasattr(response, "status_code"):
+        status_code = response.status_code
 
     return status_code

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -11,6 +11,7 @@ from datadog_lambda.trigger import (
     parse_event_source,
     get_event_source_arn,
     extract_trigger_tags,
+    extract_http_status_code_tag,
 )
 
 event_samples = "tests/event_samples/"
@@ -328,3 +329,18 @@ class GetTriggerTags(unittest.TestCase):
             event = json.load(event)
         tags = extract_trigger_tags(event, ctx)
         self.assertEqual(tags, {})
+
+
+class ExtractHTTPStatusCodeTag(unittest.TestCase):
+    def test_extract_http_status_code_tag_from_response_dict(self):
+        trigger_tags = {"function_trigger.event_source": "api-gateway"}
+        response = {"statusCode": 403}
+        status_code = extract_http_status_code_tag(trigger_tags, response)
+        self.assertEqual(status_code, 403)
+
+    def test_extract_http_status_code_tag_from_response_object(self):
+        trigger_tags = {"function_trigger.event_source": "api-gateway"}
+        response = MagicMock(spec=["status_code"])
+        response.status_code = 403
+        status_code = extract_http_status_code_tag(trigger_tags, response)
+        self.assertEqual(status_code, 403)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix `AttributeError: 'Response' object has no attribute 'get'` when used in an AWS Chalice project by making the code more robust. AWS Chalice function returns a [Response object](https://aws.github.io/chalice/api.html?highlight=response#Response) instead of a dict.

### Motivation

Make datadog-lambda work for AWS Chalice projects.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
