### PR TITLE
Type check Lambda events when extracting trigger tags

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -39,6 +39,8 @@ def parse_event_source(event):
         api-gateway | application-load-balancer | cloudwatch-logs |
         cloudwatch-events | cloudfront | dynamodb | kinesis | s3 | sns | sqs
     """
+    if type(event) is not dict:
+        return
     event_source = event.get("eventSource") or event.get("EventSource")
 
     request_context = event.get("requestContext")

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -330,6 +330,12 @@ class GetTriggerTags(unittest.TestCase):
         tags = extract_trigger_tags(event, ctx)
         self.assertEqual(tags, {})
 
+    def test_extract_trigger_tags_list_type_event(self):
+        event = []
+        ctx = get_mock_context()
+        tags = extract_trigger_tags(event, ctx)
+        self.assertEqual(tags, {})
+
 
 class ExtractHTTPStatusCodeTag(unittest.TestCase):
     def test_extract_http_status_code_tag_from_response_dict(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Short circuits trigger tag extraction if the event is not a dictionary. An event can be any type so we should not throw an exception.

### Motivation

<!--- What inspired you to submit this pull request? --->
Raised by a customer.

### Testing Guidelines

<!--- How did you test this pull request? --->
Built and tested locally. Added a unit test for good measure.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
