### PR TITLE
catch xray subsegment creation exceptions

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -114,7 +114,11 @@ def create_dd_dummy_metadata_subsegment(
         )
         xray_recorder.end_subsegment()
     except Exception as e:
-        logger.debug("failed to create dd dummy metadata subsegment with error %s", e)
+        logger.debug(
+            "failed to create dd dummy metadata subsegment with error %s",
+            e,
+            exc_info=True,
+        )
 
 
 def extract_context_from_lambda_context(lambda_context):

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -106,12 +106,15 @@ def create_dd_dummy_metadata_subsegment(
     tags into its metadata field, so the X-Ray trace can be converted to a Datadog
     trace in the Datadog backend with the correct context.
     """
-    xray_recorder.begin_subsegment(XraySubsegment.NAME)
-    subsegment = xray_recorder.current_subsegment()
-    subsegment.put_metadata(
-        subsegment_metadata_key, subsegment_metadata_value, XraySubsegment.NAMESPACE
-    )
-    xray_recorder.end_subsegment()
+    try:
+        xray_recorder.begin_subsegment(XraySubsegment.NAME)
+        subsegment = xray_recorder.current_subsegment()
+        subsegment.put_metadata(
+            subsegment_metadata_key, subsegment_metadata_value, XraySubsegment.NAMESPACE
+        )
+        xray_recorder.end_subsegment()
+    except Exception as e:
+        logger.debug("failed to create dd dummy metadata subsegment with error %s", e)
 
 
 def extract_context_from_lambda_context(lambda_context):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Wraps logic that creates the dummy dd Xray subsegment in a `try...except` and logs the error.

### Motivation

<!--- What inspired you to submit this pull request? --->
Issue raised where xray can't create a segment in Govcloud at times. This leads to xray being unable to create a subsegment and the function fails trying to write metadata to a None object.

### Testing Guidelines

<!--- How did you test this pull request? --->
Testing run automatically via github actions.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
