### PR TITLE
Check extension exists before calling hello route

### DIFF
--- a/datadog_lambda/extension.py
+++ b/datadog_lambda/extension.py
@@ -9,6 +9,7 @@ EXTENSION_PATH = "/opt/extensions/datadog-agent"
 
 logger = logging.getLogger(__name__)
 
+
 def is_extension_running():
     if not path.exists(EXTENSION_PATH):
         return False

--- a/datadog_lambda/extension.py
+++ b/datadog_lambda/extension.py
@@ -1,14 +1,17 @@
 import logging
 import requests
+from os import path
 
 AGENT_URL = "http://127.0.0.1:8124"
 HELLO_PATH = "/lambda/hello"
 FLUSH_PATH = "/lambda/flush"
+EXTENSION_PATH = "/opt/extensions/datadog-agent"
 
 logger = logging.getLogger(__name__)
 
-
 def is_extension_running():
+    if not path.exists(EXTENSION_PATH):
+        return False
     try:
         requests.get(AGENT_URL + HELLO_PATH)
     except Exception as e:


### PR DESCRIPTION
### What does this PR do?

Changes logic for extension detection, to first check if the extension exists on disk. This is consistent with behavior in the node layer.

### Motivation

Without this check, if a proxy is enabled on the lambda, it's possible that local host connections to the extension will be redirected through the proxy, incorrectly marking the extension as detected.

### Testing Guidelines


### Additional Notes


### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
