### PR TITLE
Define span on init for local invocations

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -95,6 +95,7 @@ class _LambdaDecorator(object):
             self.function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "function")
             self.extractor_env = os.environ.get("DD_TRACE_EXTRACTOR", None)
             self.trace_extractor = None
+            self.span = None
 
             if self.extractor_env:
                 extractor_parts = self.extractor_env.rsplit(".", 1)
@@ -146,7 +147,6 @@ class _LambdaDecorator(object):
                     dd_context, XraySubsegment.TRACE_KEY
                 )
 
-            self.span = None
             if dd_tracing_enabled:
                 set_dd_trace_py_root(trace_context_source, self.merge_xray_traces)
                 self.span = create_function_execution_span(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Sets `self.span = None` in the constructor.

### Motivation

<!--- What inspired you to submit this pull request? --->
Users invoking their function locally with our layer will run into the error `'_LambdaDecorator' object has no attribute 'span'`.

### Testing Guidelines

<!--- How did you test this pull request? --->
Passes unit + integration tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
