### PR TITLE
Support decrypting API keys encrypted with an encryption context

### DIFF
--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -14,12 +14,10 @@ def set_cold_start():
 
 
 def is_cold_start():
-    """Returns the value of the global cold_start
-    """
+    """Returns the value of the global cold_start"""
     return _cold_start
 
 
 def get_cold_start_tag():
-    """Returns the cold start tag to be used in metrics
-    """
+    """Returns the cold start tag to be used in metrics"""
     return "cold_start:{}".format(str(is_cold_start()).lower())

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -240,13 +240,15 @@ def decrypt_kms_api_key(kms_client, ciphertext):
             EncryptionContext={
                 KMS_ENCRYPTION_CONTEXT_KEY: function_name,
             },
-        )["Plaintext"].decode('utf-8')
+        )["Plaintext"].decode("utf-8")
     except ClientError:
         logger.debug(
             "Failed to decrypt ciphertext with encryption context, retrying without"
         )
         # Try without encryption context
-        plaintext = kms_client.decrypt(CiphertextBlob=decoded_bytes)["Plaintext"].decode('utf-8')
+        plaintext = kms_client.decrypt(CiphertextBlob=decoded_bytes)[
+            "Plaintext"
+        ].decode("utf-8")
 
     return plaintext
 

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -240,13 +240,13 @@ def decrypt_kms_api_key(kms_client, ciphertext):
             EncryptionContext={
                 KMS_ENCRYPTION_CONTEXT_KEY: function_name,
             },
-        )["Plaintext"]
+        )["Plaintext"].decode('utf-8')
     except ClientError:
         logger.debug(
             "Failed to decrypt ciphertext with encryption context, retrying without"
         )
         # Try without encryption context
-        plaintext = kms_client.decrypt(CiphertextBlob=decoded_bytes)["Plaintext"]
+        plaintext = kms_client.decrypt(CiphertextBlob=decoded_bytes)["Plaintext"].decode('utf-8')
 
     return plaintext
 

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -243,7 +243,7 @@ def decrypt_kms_api_key(kms_client, ciphertext):
         )["Plaintext"]
     except ClientError:
         logger.debug(
-            "Failed to decrypt ciphertext with encryption context, retrying without encryption context"
+            "Failed to decrypt ciphertext with encryption context, retrying without"
         )
         # Try without encryption context
         plaintext = kms_client.decrypt(CiphertextBlob=decoded_bytes)["Plaintext"]

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -226,10 +226,11 @@ def decrypt_kms_api_key(kms_client, ciphertext):
     decoded_bytes = base64.b64decode(ciphertext)
 
     """
-    The Lambda console UI changed the way it encrypts environment variables.
-    The current behavior as of May 2021 is to encrypt environment variables using the function name as an encryption context.
-    Previously, the behavior was to encrypt environment variables without an encryption context.
-    We need to try both, as supplying the incorrect encryption context will cause decryption to fail.
+    The Lambda console UI changed the way it encrypts environment variables. The current behavior
+    as of May 2021 is to encrypt environment variables using the function name as an encryption
+    context. Previously, the behavior was to encrypt environment variables without an encryption
+    context. We need to try both, as supplying the incorrect encryption context will cause
+    decryption to fail.
     """
     # Try with encryption context
     function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")

--- a/datadog_lambda/module_name.py
+++ b/datadog_lambda/module_name.py
@@ -1,4 +1,3 @@
 def modify_module_name(module_name):
-    """Returns a valid modified module to get imported
-    """
+    """Returns a valid modified module to get imported"""
     return ".".join(module_name.split("/"))

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -93,7 +93,10 @@ def get_enhanced_metrics_tags(lambda_context):
 
 
 def check_if_number(alias):
-    """Check if the alias is a version or number. Python 2 has no easy way to test this like Python 3"""
+    """
+    Check if the alias is a version or number.
+    Python 2 has no easy way to test this like Python 3
+    """
     try:
         float(alias)
         return True

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -69,8 +69,7 @@ def parse_lambda_tags_from_arn(lambda_context):
 
 
 def get_runtime_tag():
-    """Get the runtime tag from the current Python version
-    """
+    """Get the runtime tag from the current Python version"""
     major_version, minor_version, _ = python_version_tuple()
 
     return "runtime:python{major}.{minor}".format(
@@ -79,14 +78,12 @@ def get_runtime_tag():
 
 
 def get_library_version_tag():
-    """Get datadog lambda library tag
-    """
+    """Get datadog lambda library tag"""
     return "datadog_lambda:v{}".format(__version__)
 
 
 def get_enhanced_metrics_tags(lambda_context):
-    """Get the list of tags to apply to enhanced metrics
-    """
+    """Get the list of tags to apply to enhanced metrics"""
     return parse_lambda_tags_from_arn(lambda_context) + [
         get_cold_start_tag(),
         "memorysize:{}".format(lambda_context.memory_limit_in_mb),
@@ -96,8 +93,7 @@ def get_enhanced_metrics_tags(lambda_context):
 
 
 def check_if_number(alias):
-    """ Check if the alias is a version or number. Python 2 has no easy way to test this like Python 3
-    """
+    """Check if the alias is a version or number. Python 2 has no easy way to test this like Python 3"""
     try:
         float(alias)
         return True

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -186,7 +186,11 @@ def extract_context_custom_extractor(extractor, event, lambda_context):
     Extract Datadog trace context using a custom trace extractor function
     """
     try:
-        (trace_id, parent_id, sampling_priority,) = extractor(event, lambda_context)
+        (
+            trace_id,
+            parent_id,
+            sampling_priority,
+        ) = extractor(event, lambda_context)
         return trace_id, parent_id, sampling_priority
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
@@ -205,9 +209,11 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
     trace_context_source = None
 
     if extractor is not None:
-        (trace_id, parent_id, sampling_priority,) = extract_context_custom_extractor(
-            extractor, event, lambda_context
-        )
+        (
+            trace_id,
+            parent_id,
+            sampling_priority,
+        ) = extract_context_custom_extractor(extractor, event, lambda_context)
     elif "headers" in event:
         (
             trace_id,

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -6,7 +6,7 @@ if [ "$PYTHON_VERSION" = "2" ]; then
     echo "Skipping formatting, black not compatible with python 2"
     exit 0
 fi
-pip install -Iv black==19.10b0
+pip install -Iv black==20.8b1
 
 python -m black --check datadog_lambda/ --diff
 python -m black --check tests --diff

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -6,7 +6,7 @@ if [ "$PYTHON_VERSION" = "2" ]; then
     echo "Skipping formatting, black not compatible with python 2"
     exit 0
 fi
-pip install -Iv black==20.8b1
+pip install -Iv black==21.5b2
 
 python -m black --check datadog_lambda/ --diff
 python -m black --check tests --diff

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         # If building for Python 3, use the latest version of setuptools
         "setuptools>=54.2.0; python_version >= '3.0'",
         # If building for Python 2, use the latest version that supports Python 2
-        "setuptools>=44.1.1; python_version < '3.0'"
+        "setuptools>=44.1.1; python_version < '3.0'",
     ],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -83,7 +83,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         os.environ["AWS_LAMBDA_FUNCTION_NAME"] = MOCK_FUNCTION_NAME
 
         class MockKMSClient:
-            def decrypt(self, CiphertextBlob=None, EncryptionContext=None):
+            def decrypt(self, CiphertextBlob=None, EncryptionContext={}):
                 if (
                     EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
                     != MOCK_FUNCTION_NAME
@@ -104,7 +104,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
 
     def test_key_encrypted_without_encryption_context(self):
         class MockKMSClient:
-            def decrypt(self, CiphertextBlob=None, EncryptionContext=None):
+            def decrypt(self, CiphertextBlob=None, EncryptionContext={}):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
                     raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -83,7 +83,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         os.environ["AWS_LAMBDA_FUNCTION_NAME"] = self.mock_function_name
 
         class MockKMSClient:
-            def decrypt(CiphertextBlob=None, EncryptionContext=None):
+            def decrypt(self, CiphertextBlob, EncryptionContext):
                 if (
                     EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
                     != self.mock_function_name
@@ -104,7 +104,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
 
     def test_key_encrypted_without_encryption_context(self):
         class MockKMSClient:
-            def decrypt(CiphertextBlob=None, EncryptionContext=None):
+            def decrypt(self, CiphertextBlob, EncryptionContext):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
                     raise BotocoreClientError()
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -18,6 +18,7 @@ from datadog_lambda.tags import _format_dd_lambda_layer_tag
 
 MOCK_FUNCTION_NAME = "myFunction"
 
+
 class TestLambdaMetric(unittest.TestCase):
     def setUp(self):
         patcher = patch("datadog_lambda.metric.lambda_stats")

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -88,7 +88,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
                     EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
                     != MOCK_FUNCTION_NAME
                 ):
-                    raise BotocoreClientError("Error", "Decrypt")
+                    raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,
@@ -106,7 +106,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         class MockKMSClient:
             def decrypt(self, CiphertextBlob, EncryptionContext):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
-                    raise BotocoreClientError("Error", "Decrypt")
+                    raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -12,7 +12,7 @@ from datadog_lambda.metric import (
     decrypt_kms_api_key,
     lambda_metric,
     ThreadStatsWriter,
-    KMS_ENCRYPTION_CONTEXT_KEY
+    KMS_ENCRYPTION_CONTEXT_KEY,
 )
 from datadog_lambda.tags import _format_dd_lambda_layer_tag
 
@@ -84,30 +84,36 @@ class TestDecryptKMSApiKey(unittest.TestCase):
 
         class MockKMSClient:
             def decrypt(CiphertextBlob=None, EncryptionContext=None):
-                if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != self.mock_function_name:
+                if (
+                    EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
+                    != self.mock_function_name
+                ):
                     raise BotocoreClientError()
-                if CiphertextBlob == self.mock_encrypted_api_key.encode('utf-8'):
+                if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,
-                    } 
+                    }
 
         mock_kms_client = MockKMSClient()
-        decrypted_key = decrypt_kms_api_key(mock_kms_client, self.mock_encrypted_api_key_base64)
+        decrypted_key = decrypt_kms_api_key(
+            mock_kms_client, self.mock_encrypted_api_key_base64
+        )
         self.assertEqual(decrypted_key, self.expected_decrypted_api_key)
 
         del os.environ["AWS_LAMBDA_FUNCTION_NAME"]
-    
-    def test_key_encrypted_without_encryption_context(self):
 
+    def test_key_encrypted_without_encryption_context(self):
         class MockKMSClient:
             def decrypt(CiphertextBlob=None, EncryptionContext=None):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
                     raise BotocoreClientError()
-                if CiphertextBlob == self.mock_encrypted_api_key.encode('utf-8'):
+                if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,
                     }
-        
+
         mock_kms_client = MockKMSClient()
-        decrypted_key = decrypt_kms_api_key(mock_kms_client, self.mock_encrypted_api_key_base64)
+        decrypted_key = decrypt_kms_api_key(
+            mock_kms_client, self.mock_encrypted_api_key_base64
+        )
         self.assertEqual(decrypted_key, self.expected_decrypted_api_key)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -16,6 +16,7 @@ from datadog_lambda.metric import (
 )
 from datadog_lambda.tags import _format_dd_lambda_layer_tag
 
+MOCK_FUNCTION_NAME = "myFunction"
 
 class TestLambdaMetric(unittest.TestCase):
     def setUp(self):
@@ -68,8 +69,6 @@ class TestFlushThreadStats(unittest.TestCase):
 
 class TestDecryptKMSApiKey(unittest.TestCase):
 
-    mock_function_name = "myFunction"
-
     # An API key encrypted with KMS and encoded as a base64 string
     mock_encrypted_api_key_base64 = "MjIyMjIyMjIyMjIyMjIyMg=="
 
@@ -80,15 +79,15 @@ class TestDecryptKMSApiKey(unittest.TestCase):
     expected_decrypted_api_key = "1111111111111111"
 
     def test_key_encrypted_with_encryption_context(self):
-        os.environ["AWS_LAMBDA_FUNCTION_NAME"] = self.mock_function_name
+        os.environ["AWS_LAMBDA_FUNCTION_NAME"] = MOCK_FUNCTION_NAME
 
         class MockKMSClient:
             def decrypt(self, CiphertextBlob, EncryptionContext):
                 if (
                     EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
-                    != self.mock_function_name
+                    != MOCK_FUNCTION_NAME
                 ):
-                    raise BotocoreClientError()
+                    raise BotocoreClientError("Error", "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,
@@ -106,7 +105,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         class MockKMSClient:
             def decrypt(self, CiphertextBlob, EncryptionContext):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
-                    raise BotocoreClientError()
+                    raise BotocoreClientError("Error", "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):
                     return {
                         "Plaintext": self.expected_decrypted_api_key,

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -91,7 +91,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
                     raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == MOCK_ENCRYPTED_API_KEY.encode("utf-8"):
                     return {
-                        "Plaintext": EXPECTED_DECRYPTED_API_KEY,
+                        "Plaintext": EXPECTED_DECRYPTED_API_KEY.encode("utf-8"),
                     }
 
         mock_kms_client = MockKMSClient()
@@ -109,7 +109,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
                     raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == MOCK_ENCRYPTED_API_KEY.encode("utf-8"):
                     return {
-                        "Plaintext": EXPECTED_DECRYPTED_API_KEY,
+                        "Plaintext": EXPECTED_DECRYPTED_API_KEY.encode("utf-8"),
                     }
 
         mock_kms_client = MockKMSClient()

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -83,7 +83,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         os.environ["AWS_LAMBDA_FUNCTION_NAME"] = self.mock_function_name
 
         class MockKMSClient:
-            def decrypt(CiphertextBlob, EncryptionContext):
+            def decrypt(CiphertextBlob=None, EncryptionContext=None):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != self.mock_function_name:
                     raise BotocoreClientError()
                 if CiphertextBlob == self.mock_encrypted_api_key.encode('utf-8'):
@@ -100,7 +100,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
     def test_key_encrypted_without_encryption_context(self):
 
         class MockKMSClient:
-            def decrypt(CiphertextBlob, EncryptionContext):
+            def decrypt(CiphertextBlob=None, EncryptionContext=None):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
                     raise BotocoreClientError()
                 if CiphertextBlob == self.mock_encrypted_api_key.encode('utf-8'):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -16,6 +16,7 @@ from datadog_lambda.metric import (
 )
 from datadog_lambda.tags import _format_dd_lambda_layer_tag
 
+
 class TestLambdaMetric(unittest.TestCase):
     def setUp(self):
         patcher = patch("datadog_lambda.metric.lambda_stats")
@@ -64,6 +65,7 @@ class TestFlushThreadStats(unittest.TestCase):
         lambda_stats.flush()
         self.assertEqual(self.mock_threadstats_flush_distributions.call_count, 2)
 
+
 MOCK_FUNCTION_NAME = "myFunction"
 
 # An API key encrypted with KMS and encoded as a base64 string
@@ -74,8 +76,9 @@ MOCK_ENCRYPTED_API_KEY = "2222222222222222"
 
 # The true value of the API key after decryption by KMS
 EXPECTED_DECRYPTED_API_KEY = "1111111111111111"
-class TestDecryptKMSApiKey(unittest.TestCase):
 
+
+class TestDecryptKMSApiKey(unittest.TestCase):
     def test_key_encrypted_with_encryption_context(self):
         os.environ["AWS_LAMBDA_FUNCTION_NAME"] = MOCK_FUNCTION_NAME
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -83,7 +83,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
         os.environ["AWS_LAMBDA_FUNCTION_NAME"] = MOCK_FUNCTION_NAME
 
         class MockKMSClient:
-            def decrypt(self, CiphertextBlob, EncryptionContext):
+            def decrypt(self, CiphertextBlob=None, EncryptionContext=None):
                 if (
                     EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY)
                     != MOCK_FUNCTION_NAME
@@ -104,7 +104,7 @@ class TestDecryptKMSApiKey(unittest.TestCase):
 
     def test_key_encrypted_without_encryption_context(self):
         class MockKMSClient:
-            def decrypt(self, CiphertextBlob, EncryptionContext):
+            def decrypt(self, CiphertextBlob=None, EncryptionContext=None):
                 if EncryptionContext.get(KMS_ENCRYPTION_CONTEXT_KEY) != None:
                     raise BotocoreClientError({}, "Decrypt")
                 if CiphertextBlob == self.mock_encrypted_api_key.encode("utf-8"):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -73,7 +73,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx,
+            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -93,7 +94,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx,
+            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -118,7 +120,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
+            ctx,
+            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -160,7 +163,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "123",
+                "parent-id": "321",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -189,7 +197,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2",},
+            ctx,
+            {
+                "trace-id": "4369",
+                "parent-id": "65535",
+                "sampling-priority": "2",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -235,7 +248,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context(sqs_event, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "123",
+                "parent-id": "321",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -267,7 +285,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "666", "parent-id": "777", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "666",
+                "parent-id": "777",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),


### PR DESCRIPTION
### What does this PR do?

When decrypting the API key using KMS, try first with the encryption context added by the Lambda console UI, then try without.

Bonus: Updates `black` (the code formatter) to v21.

### Motivation

The Lambda console UI changed the way it encrypts environment variables. The current behavior is to encrypt environment variables using the function name as an encryption context. Previously, the behavior was to encrypt environment variables without an encryption context. The Lambda Extension currently only supports API keys encrypted using the previous behavior. We need to support both, as supplying the incorrect encryption context will cause decryption to fail.

### Testing Guidelines

I added unit test coverage for this function and tested manually.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
