### PR TITLE
Check for the new direct invocation trace format and use that

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -237,9 +237,7 @@ def decrypt_kms_api_key(kms_client, ciphertext):
     try:
         plaintext = kms_client.decrypt(
             CiphertextBlob=decoded_bytes,
-            EncryptionContext={
-                KMS_ENCRYPTION_CONTEXT_KEY: function_name,
-            },
+            EncryptionContext={KMS_ENCRYPTION_CONTEXT_KEY: function_name,},
         )["Plaintext"].decode("utf-8")
     except ClientError:
         logger.debug(

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -237,7 +237,9 @@ def decrypt_kms_api_key(kms_client, ciphertext):
     try:
         plaintext = kms_client.decrypt(
             CiphertextBlob=decoded_bytes,
-            EncryptionContext={KMS_ENCRYPTION_CONTEXT_KEY: function_name,},
+            EncryptionContext={
+                KMS_ENCRYPTION_CONTEXT_KEY: function_name,
+            },
         )["Plaintext"].decode("utf-8")
     except ClientError:
         logger.debug(

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import json
-from typing import Optional
+from typing import Optional  # noqa: F401
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.lambda_launcher import LambdaContext

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import json
+from typing import Optional
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.lambda_launcher import LambdaContext
@@ -129,16 +130,27 @@ def extract_context_from_lambda_context(lambda_context):
     dd_trace libraries inject this trace context on synchronous invocations
     """
     client_context = lambda_context.client_context
-
+    trace_id = None  # type: Optional[str]
+    parent_id = None  # type: Optional[str]
+    sampling_priority = None  # type: Optional[str]
     if client_context and client_context.custom:
-        dd_data = client_context.custom.get("_datadog", {})
-        trace_id = dd_data.get(TraceHeader.TRACE_ID)
-        parent_id = dd_data.get(TraceHeader.PARENT_ID)
-        sampling_priority = dd_data.get(TraceHeader.SAMPLING_PRIORITY)
+        if "_datadog" in client_context.custom:
+            # Legacy trace propagation dict
+            dd_data = client_context.custom.get("_datadog", {})
+            trace_id = dd_data.get(TraceHeader.TRACE_ID)
+            parent_id = dd_data.get(TraceHeader.PARENT_ID)
+            sampling_priority = dd_data.get(TraceHeader.SAMPLING_PRIORITY)
+        elif (
+            TraceHeader.TRACE_ID in client_context.custom
+            and TraceHeader.PARENT_ID in client_context.custom
+            and TraceHeader.SAMPLING_PRIORITY in client_context.custom
+        ):
+            # New trace propagation keys
+            trace_id = client_context.custom.get(TraceHeader.TRACE_ID)
+            parent_id = client_context.custom.get(TraceHeader.PARENT_ID)
+            sampling_priority = client_context.custom.get(TraceHeader.SAMPLING_PRIORITY)
 
-        return trace_id, parent_id, sampling_priority
-
-    return None, None, None
+    return trace_id, parent_id, sampling_priority
 
 
 def extract_context_from_http_event_or_context(event, lambda_context):
@@ -186,11 +198,7 @@ def extract_context_custom_extractor(extractor, event, lambda_context):
     Extract Datadog trace context using a custom trace extractor function
     """
     try:
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extractor(event, lambda_context)
+        (trace_id, parent_id, sampling_priority,) = extractor(event, lambda_context)
         return trace_id, parent_id, sampling_priority
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
@@ -209,11 +217,9 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
     trace_context_source = None
 
     if extractor is not None:
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_custom_extractor(extractor, event, lambda_context)
+        (trace_id, parent_id, sampling_priority,) = extract_context_custom_extractor(
+            extractor, event, lambda_context
+        )
     elif "headers" in event:
         (
             trace_id,

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -225,9 +225,7 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
             trace_id,
             parent_id,
             sampling_priority,
-        ) = extract_context_custom_extractor(
-            extractor, event, lambda_context
-        )
+        ) = extract_context_custom_extractor(extractor, event, lambda_context)
     elif "headers" in event:
         (
             trace_id,

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -198,7 +198,11 @@ def extract_context_custom_extractor(extractor, event, lambda_context):
     Extract Datadog trace context using a custom trace extractor function
     """
     try:
-        (trace_id, parent_id, sampling_priority,) = extractor(event, lambda_context)
+        (
+            trace_id,
+            parent_id,
+            sampling_priority,
+        ) = extractor(event, lambda_context)
         return trace_id, parent_id, sampling_priority
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
@@ -217,7 +221,11 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
     trace_context_source = None
 
     if extractor is not None:
-        (trace_id, parent_id, sampling_priority,) = extract_context_custom_extractor(
+        (
+            trace_id,
+            parent_id,
+            sampling_priority,
+        ) = extract_context_custom_extractor(
             extractor, event, lambda_context
         )
     elif "headers" in event:

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -6,7 +6,6 @@
 import logging
 import os
 import json
-from typing import Optional  # noqa: F401
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core.lambda_launcher import LambdaContext
@@ -130,9 +129,9 @@ def extract_context_from_lambda_context(lambda_context):
     dd_trace libraries inject this trace context on synchronous invocations
     """
     client_context = lambda_context.client_context
-    trace_id = None  # type: Optional[str]
-    parent_id = None  # type: Optional[str]
-    sampling_priority = None  # type: Optional[str]
+    trace_id = None
+    parent_id = None
+    sampling_priority = None
     if client_context and client_context.custom:
         if "_datadog" in client_context.custom:
             # Legacy trace propagation dict

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -73,8 +73,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx,
-            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -94,8 +93,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx,
-            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -120,8 +118,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx,
-            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
+            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -163,12 +160,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "event")
         self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "123",
-                "parent-id": "321",
-                "sampling-priority": "1",
-            },
+            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -197,12 +189,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "xray")
         self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "4369",
-                "parent-id": "65535",
-                "sampling-priority": "2",
-            },
+            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2",},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -248,12 +235,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context(sqs_event, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "123",
-                "parent-id": "321",
-                "sampling-priority": "1",
-            },
+            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -285,12 +267,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "666",
-                "parent-id": "777",
-                "sampling-priority": "1",
-            },
+            ctx, {"trace-id": "666", "parent-id": "777", "sampling-priority": "1",},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -320,12 +297,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "666",
-                "parent-id": "777",
-                "sampling-priority": "1",
-            },
+            ctx, {"trace-id": "666", "parent-id": "777", "sampling-priority": "1",},
         )
         self.assertDictEqual(
             get_dd_trace_context(),

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -73,7 +73,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx,
+            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -93,7 +94,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
+            ctx,
+            {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -118,7 +120,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
+            ctx,
+            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -160,7 +163,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "123",
+                "parent-id": "321",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -189,7 +197,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         self.assertEquals(ctx_source, "xray")
         self.assertDictEqual(
-            ctx, {"trace-id": "4369", "parent-id": "65535", "sampling-priority": "2",},
+            ctx,
+            {
+                "trace-id": "4369",
+                "parent-id": "65535",
+                "sampling-priority": "2",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -235,7 +248,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context(sqs_event, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "123", "parent-id": "321", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "123",
+                "parent-id": "321",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -267,7 +285,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "666", "parent-id": "777", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "666",
+                "parent-id": "777",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),
@@ -297,7 +320,12 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
         self.assertDictEqual(
-            ctx, {"trace-id": "666", "parent-id": "777", "sampling-priority": "1",},
+            ctx,
+            {
+                "trace-id": "666",
+                "parent-id": "777",
+                "sampling-priority": "1",
+            },
         )
         self.assertDictEqual(
             get_dd_trace_context(),


### PR DESCRIPTION
### What does this PR do?

Updates datadog-lambda-python so it can extract trace contexts stored in `context.client_context.custom` using the new propagation format, described in this doc: https://docs.google.com/document/d/1pruSeesAr2bAVMtz_rUlsiBZKFoFWdB4nSq5Vuym2l8/edit#heading=h.ptr8uhqw5ht

### Motivation

Storing a map containing trace context in `context.client_context.custom._datadog` causes compatibility issues with Go and Java lambda functions. C.f. https://github.com/aws/aws-lambda-java-libs/issues/212. We're updating the trace propagation format to fix this issue.

### Testing Guidelines

<!--- How did you test this pull request? --->

- Added a unit test

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
