### PR TITLE
fix hello route hit too early

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 lambda_stats = None
 
+
 class StatsWriter:
     def distribution(self, metric_name, value, tags=[], timestamp=None):
         raise NotImplementedError()

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -12,6 +12,7 @@ from datadog_lambda.extension import should_use_extension, flush_extension
 from datadog_lambda.cold_start import set_cold_start, is_cold_start
 from datadog_lambda.constants import XraySubsegment, TraceContextSource
 from datadog_lambda.metric import (
+    init_lambda_stats,
     flush_stats,
     submit_invocations_metric,
     submit_errors_metric,
@@ -119,6 +120,7 @@ class _LambdaDecorator(object):
         """Executes when the wrapped function gets called"""
         self.trigger_tags = extract_trigger_tags(event, context)
         self.response = None
+        init_lambda_stats()
         self._before(event, context)
         try:
             self.response = self.func(event, context, **kwargs)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -133,10 +133,10 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
 
     def test_datadog_lambda_wrapper_flush_in_thread(self):
         # force ThreadStats to flush in thread
+        os.environ["DD_FLUSH_IN_THREAD"] = "True"
         import datadog_lambda.metric as metric_module
-
         metric_module.lambda_stats.stop()
-        metric_module.lambda_stats = ThreadStatsWriter(True)
+        metric_module.init_lambda_stats()
 
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
@@ -157,6 +157,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         # reset ThreadStats
         metric_module.lambda_stats.stop()
         metric_module.lambda_stats = ThreadStatsWriter(False)
+        del os.environ["DD_FLUSH_IN_THREAD"]
 
     def test_datadog_lambda_wrapper_not_flush_in_thread(self):
         # force ThreadStats to not flush in thread

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -135,6 +135,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         # force ThreadStats to flush in thread
         os.environ["DD_FLUSH_IN_THREAD"] = "True"
         import datadog_lambda.metric as metric_module
+
         metric_module.lambda_stats.stop()
         metric_module.init_lambda_stats()
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Call the /hello route at the right moment

### Motivation

Consistency in metric tagging with the extension

### Testing Guidelines

With integration testing

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
