### PR TITLE
Ensure http.status_code is always a string

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -214,4 +214,4 @@ def extract_http_status_code_tag(trigger_tags, response):
     elif hasattr(response, "status_code"):
         status_code = response.status_code
 
-    return status_code
+    return str(status_code)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -342,11 +342,11 @@ class ExtractHTTPStatusCodeTag(unittest.TestCase):
         trigger_tags = {"function_trigger.event_source": "api-gateway"}
         response = {"statusCode": 403}
         status_code = extract_http_status_code_tag(trigger_tags, response)
-        self.assertEqual(status_code, 403)
+        self.assertEqual(status_code, "403")
 
     def test_extract_http_status_code_tag_from_response_object(self):
         trigger_tags = {"function_trigger.event_source": "api-gateway"}
         response = MagicMock(spec=["status_code"])
         response.status_code = 403
         status_code = extract_http_status_code_tag(trigger_tags, response)
-        self.assertEqual(status_code, 403)
+        self.assertEqual(status_code, "403")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Always converts the status code found in the event that invokes the Lambda to a string.

### Motivation

<!--- What inspired you to submit this pull request? --->
APM expects that `http.status_code` should always be a string. If we find a `statusCode`/`status_code` field in the event that invokes the Lambda function, it can be an integer.

### Testing Guidelines

<!--- How did you test this pull request? --->
Updated existing tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
