### PR TITLE
Updates aws-xray-sdk to version 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=["datadog_lambda"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
     install_requires=[
-        "aws-xray-sdk==2.6.0",
+        "aws-xray-sdk==2.8.0",
         "datadog==0.41.0",
         "ddtrace==0.48.0",
         "wrapt==1.11.2",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates dependency aws-xray-sdk to latest version 2.8.0

### Motivations

I was running into an incompatible version conflict with aws-lambda-powertools and Datadog-lambda-python

aws-xray-sdk<3.0.0,>=2.8.0 (from aws-lambda-powertools==1.17.1

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I ran the unit tests locally with docker running using

./scripts/run_tests.sh

### Additional Notes

I will need someone to run the integration tests for me!

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
