### PR TITLE
Only replace the logging formatter if it is a logging.Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If `DD_FLUSH_TO_LOG` is set to `false` (not recommended), you must set `DD_SITE`
 
 ### DD_LOGS_INJECTION
 
-Inject Datadog trace id into logs for [correlation](https://docs.datadoghq.com/tracing/connect_logs_and_traces/python/). Defaults to `true`.
+Inject Datadog trace id into logs for [correlation](https://docs.datadoghq.com/tracing/connect_logs_and_traces/python/) if you are using a `logging.Formatter` in the default `LambdaLoggerHandler` by the Lambda runtime. Defaults to `true`.
 
 ### DD_LOG_LEVEL
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -336,7 +336,10 @@ def inject_correlation_ids():
     # Override the log format of the AWS provided LambdaLoggerHandler
     root_logger = logging.getLogger()
     for handler in root_logger.handlers:
-        if handler.__class__.__name__ == "LambdaLoggerHandler":
+        if (
+            handler.__class__.__name__ == "LambdaLoggerHandler"
+            and type(handler.formatter) == logging.Formatter
+        ):
             handler.setFormatter(
                 logging.Formatter(
                     "[%(levelname)s]\t%(asctime)s.%(msecs)dZ\t%(aws_request_id)s\t"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Makes the trace context log injection code check the type of the logging Formatter before replacing the Formatter. If the user is using a JSON formatter, it will pick up the trace context from the [dummy span that contains the trace context](https://github.com/DataDog/datadog-lambda-python/pull/155/files#diff-eb1f51efb218a7a829e913e4ff6b17ce27be8a777bc20c283e5b843e5db151efL304-L325). 

<!--- A brief description of the change being made with this pull request. --->

### Motivation

#153 

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Screenshots of it working:


(JSON logging, no lambda library)
![image](https://user-images.githubusercontent.com/1136297/126838877-ba6839fd-bf0b-42c5-a4a9-2ba6362891e3.png)


(JSON logging, old version of the lambda library)
![image](https://user-images.githubusercontent.com/1136297/126840001-87f14868-2d0d-4e5c-93a5-4ab1ce481840.png)


(JSON logging, new version of the lambda library)
![image](https://user-images.githubusercontent.com/1136297/126838934-30ec6823-dfca-4817-82eb-8cd8be1ed7c6.png)


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
