### PR TITLE
Catch invocation event tag extraction exceptions

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -97,6 +97,7 @@ class _LambdaDecorator(object):
             self.extractor_env = os.environ.get("DD_TRACE_EXTRACTOR", None)
             self.trace_extractor = None
             self.span = None
+            self.response = None
 
             if self.extractor_env:
                 extractor_parts = self.extractor_env.rsplit(".", 1)
@@ -119,8 +120,6 @@ class _LambdaDecorator(object):
 
     def __call__(self, event, context, **kwargs):
         """Executes when the wrapped function gets called"""
-        self.trigger_tags = extract_trigger_tags(event, context)
-        self.response = None
         init_lambda_stats()
         self._before(event, context)
         try:
@@ -136,9 +135,9 @@ class _LambdaDecorator(object):
 
     def _before(self, event, context):
         try:
-
             set_cold_start()
             submit_invocations_metric(context)
+            self.trigger_tags = extract_trigger_tags(event, context)
             # Extract Datadog trace context and source from incoming requests
             dd_context, trace_context_source = extract_dd_trace_context(
                 event, context, extractor=self.trace_extractor


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Moves `self.response` initialization and the logic to extract span tags from the event that invokes the Lambda function within a `try...catch` so it doesn't break the Lambda.

### Motivation

<!--- What inspired you to submit this pull request? --->
In general, we shouldn't break the user's function from executing. In this case, if the invoking event is not what we expect, we can break the function from being executed. For example, an S3 event that doesn't have an `arn` field raised this error:
```
{
  "errorMessage": "'arn'",
  "errorType": "KeyError",
  "stackTrace": [
    "  File \"/opt/python/lib/python3.8/site-packages/datadog_lambda/wrapper.py\", line 55, in __call__\n    return self.func(*args, **kwargs)\n",
    ...
    "  File \"/opt/python/lib/python3.8/site-packages/datadog_lambda/trigger.py\", line 87, in parse_event_source_arn\n    return event_record.get(\"s3\")[\"bucket\"][\"arn\"]\n"
  ]
}
```

Catching the exception won't break the execution of the function and will still allow us to debug an issue.

### Testing Guidelines

<!--- How did you test this pull request? --->
Passed unit tests and integration tests. Also tested my own build of the layer.
### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
