### PR TITLE
Improve Dockerfile to cache pip install

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,9 +3,15 @@ FROM python:$python_version
 
 ENV PYTHONDONTWRITEBYTECODE True
 
-RUN mkdir -p /test
+RUN mkdir -p /test/datadog_lambda
 WORKDIR /test
+
+# Copy minimal subset of files to make pip install succeed and be cached (next docker builds will be way faster)
+COPY setup.py .
+COPY README.md .
+COPY datadog_lambda/__init__.py datadog_lambda/__init__.py 
+
+RUN pip install .[dev]
 
 # Install datadog-lambda with dev dependencies from local
 COPY . .
-RUN pip install .[dev]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Update `Dockerfile` so that `pip install` can be cached in a Docker layer.
This makes `docker build` really fast once it has built one time.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
