### PR TITLE
Remove requests for urllib

### DIFF
--- a/datadog_lambda/extension.py
+++ b/datadog_lambda/extension.py
@@ -1,6 +1,14 @@
 import logging
-import requests
 from os import path
+
+try:
+    # only available in python 3
+    # not an issue since the extension is not compatible with python 2.x runtime
+    # https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html
+    import urllib.request
+except ImportError:
+    # safe since both calls to urllib are protected with try/expect and will return false
+    urllib = None
 
 AGENT_URL = "http://127.0.0.1:8124"
 HELLO_PATH = "/lambda/hello"
@@ -14,7 +22,7 @@ def is_extension_running():
     if not path.exists(EXTENSION_PATH):
         return False
     try:
-        requests.get(AGENT_URL + HELLO_PATH)
+        urllib.request.urlopen(AGENT_URL + HELLO_PATH)
     except Exception as e:
         logger.debug("Extension is not running, returned with error %s", e)
         return False
@@ -23,7 +31,8 @@ def is_extension_running():
 
 def flush_extension():
     try:
-        requests.post(AGENT_URL + FLUSH_PATH, data={})
+        req = urllib.request.Request(AGENT_URL + FLUSH_PATH, "".encode("ascii"))
+        urllib.request.urlopen(req)
     except Exception as e:
         logger.debug("Failed to flush extension, returned with error %s", e)
         return False

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 import httpretty
 
@@ -19,6 +20,9 @@ def exceptionCallback(request, uri, headers):
 
 
 class TestLambdaExtension(unittest.TestCase):
+    # do not execute tests for Python v2.x
+    __test__ = sys.version_info >= (3, 0)
+
     @patch("datadog_lambda.extension.EXTENSION_PATH", os.path.abspath(__file__))
     def test_is_extension_running_true(self):
         httpretty.enable()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

`requests` is too heavy and slows down coldstart

### Motivation

performance optimization

### Testing Guidelines

unit + integration tests

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
