### PR TITLE
Add metric to report integration tests status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,3 +99,20 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RUNTIME_PARAM: ${{ matrix.runtime-param }}
         run: ./scripts/run_integration_tests.sh
+
+      - name: Send success metric
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        run: ./scripts/send_status_metric.sh 0 $DD_API_KEY
+
+  integration-test-failure:
+    runs-on: ubuntu-latest
+    needs: [integration-test]
+    if: always() && (needs.integration-test.result == 'failure')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Send a failure metric
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        run: ./scripts/send_status_metric.sh 1 $DD_API_KEY

--- a/scripts/send_status_metric.sh
+++ b/scripts/send_status_metric.sh
@@ -1,0 +1,29 @@
+if [ -z $GITHUB_REF ]; then
+  echo "GITHUB_REF is not set, not sending the metric"
+  exit 0
+fi
+
+if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+  echo "Not on the main branch, not sending the metric"
+  exit 0
+fi
+
+#Retrieve the status
+# 0 means success
+# 1 means failure
+STATUS=$1
+
+API_KEY=$2
+CURRENT_TIME=$(date +%s)
+
+#Send the metric
+curl -H "Content-type: application/json" \
+-H "DD-API-KEY: ${API_KEY}" \
+-d "{ \"series\" :
+         [{\"metric\":\"serverless.integration_test.python.status\",
+          \"points\":[[$CURRENT_TIME, $STATUS]],
+          \"type\":\"gauge\",
+          \"tags\":[\"service:serverless-integration-test\"]}
+        ]
+    }" \
+'https://app.datadoghq.com/api/v1/series'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Send a metric at the end of integration tests
- with value of 0 if success
- with value of 1 otherwise

This is done by inspecting the status of the integration tests step

### Motivation

Detect (via monitor + alert) when daily runs of integration tests are failing

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
