### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -170,7 +170,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             lambda_ctx,
             extractor=extractor_foo,
         )
-        self.assertEquals(ctx_source, "event")
+        self.assertEqual(ctx_source, "event")
         self.assertDictEqual(
             ctx,
             {
@@ -204,7 +204,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             lambda_ctx,
             extractor=extractor_raiser,
         )
-        self.assertEquals(ctx_source, "xray")
+        self.assertEqual(ctx_source, "xray")
         self.assertDictEqual(
             ctx,
             {


### PR DESCRIPTION
### What does this PR do?

Use assertEqual instead of assertEquals for Python 3.11 compatibility. The deprecated aliases were removed in https://github.com/python/cpython/pull/28268

### Motivation

Adds Python 3.11 support for tests.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
