### PR TITLE
Don't send x-ray trace metadata for when x-ray has filtered trace

### DIFF
--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -10,11 +10,11 @@ from datadog_lambda.constants import XrayDaemon, XraySubsegment, TraceContextSou
 logger = logging.getLogger(__name__)
 
 
-def get_xray_host_port(adress):
-    if adress == "":
+def get_xray_host_port(address):
+    if address == "":
         logger.debug("X-Ray daemon env var not set, not sending sub-segment")
         return None
-    parts = adress.split(":")
+    parts = address.split(":")
     if len(parts) <= 1:
         logger.debug("X-Ray daemon env var not set, not sending sub-segment")
         return None
@@ -107,6 +107,11 @@ def send_segment(key, metadata):
         logger.debug(
             "Failed to create segment since it was not possible to get trace context from header"
         )
+        return None
+
+    # Skip adding segment, if the xray trace is going to be sampled away.
+    if context["sampled"] == "0":
+        logger.debug("Skipping sending metadata, x-ray trace was sampled out")
         return None
     segment = build_segment(context, key, metadata)
     segment_payload = build_segment_payload(segment)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir -p /test/datadog_lambda
 WORKDIR /test
 
 # Copy minimal subset of files to make pip install succeed and be cached (next docker builds will be way faster)
-COPY setup.py .
+COPY pyproject.toml .
+COPY poetry.lock .
 COPY README.md .
 COPY datadog_lambda/__init__.py datadog_lambda/__init__.py 
 


### PR DESCRIPTION
### What does this PR do?

When writing the datadog metadata subsegment to x-ray, check the trace hasn't already been sampled.

### Motivation

Prevents sending redundant traces to x-ray in the case where user's have at some point turned on active tracing to their function.

### Testing Guidelines

I added a unit test, and tested this manually.

### Additional Notes


### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
