### PR TITLE
[SLS-1682] Fix issue with tests failing due to strftime taking timezone into account

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -27,7 +27,7 @@ from datadog_lambda.trigger import (
     EventTypes,
     EventSubtypes,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -547,7 +547,7 @@ def create_inferred_span_from_sns_event(event, context):
     }
     sns_dt_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     timestamp = event_record["Sns"]["Timestamp"]
-    request_time_epoch = datetime.strptime(timestamp, sns_dt_format)
+    dt = datetime.strptime(timestamp, sns_dt_format)
 
     args = {
         "resource": topic_name,
@@ -557,7 +557,7 @@ def create_inferred_span_from_sns_event(event, context):
     span = tracer.trace("aws.sns", **args)
     if span:
         span.set_tags(tags)
-    span.start = int(request_time_epoch.strftime("%s"))
+    span.start = dt.replace(tzinfo=timezone.utc).timestamp()
     return span
 
 
@@ -618,7 +618,7 @@ def create_inferred_span_from_s3_event(event, context):
     }
     dt_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     timestamp = event_record["eventTime"]
-    request_time_epoch = datetime.strptime(timestamp, dt_format)
+    dt = datetime.strptime(timestamp, dt_format)
 
     args = {
         "resource": bucket_name,
@@ -628,7 +628,7 @@ def create_inferred_span_from_s3_event(event, context):
     span = tracer.trace("aws.s3", **args)
     if span:
         span.set_tags(tags)
-    span.start = int(request_time_epoch.strftime("%s"))
+    span.start = dt.replace(tzinfo=timezone.utc).timestamp()
     return span
 
 
@@ -642,7 +642,7 @@ def create_inferred_span_from_eventbridge_event(event, context):
     }
     dt_format = "%Y-%m-%dT%H:%M:%SZ"
     timestamp = event["time"]
-    request_time_epoch = datetime.strptime(timestamp, dt_format)
+    dt = datetime.strptime(timestamp, dt_format)
 
     args = {
         "resource": source,
@@ -652,7 +652,7 @@ def create_inferred_span_from_eventbridge_event(event, context):
     span = tracer.trace("aws.eventbridge", **args)
     if span:
         span.set_tags(tags)
-    span.start = int(request_time_epoch.strftime("%s"))
+    span.start = dt.replace(tzinfo=timezone.utc).timestamp()
     return span
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -769,8 +769,7 @@ class TestInferredSpans(unittest.TestCase):
         )
         self.assertEqual(span.get_tag("request_id"), None)
         self.assertEqual(span.get_tag("span_type"), "inferred")
-        # TODO FIXME: investigate why this is flaky
-        # self.assertEqual(span.start, 18000.0)
+        self.assertEqual(span.start, 0.0)
         self.assertEqual(span.span_type, "web")
 
     def test_create_inferred_span_from_kinesis_event(self):
@@ -854,8 +853,7 @@ class TestInferredSpans(unittest.TestCase):
         )
         self.assertEqual(span.get_tag("request_id"), None)
         self.assertEqual(span.get_tag("span_type"), "inferred")
-        # TODO FIXME: investigate why this is flaky
-        # self.assertEqual(span.start, 18000.0)
+        self.assertEqual(span.start, 0.0)
         self.assertEqual(span.span_type, "web")
 
     def test_create_inferred_span_from_eventbridge_event(self):
@@ -883,6 +881,5 @@ class TestInferredSpans(unittest.TestCase):
         )
         self.assertEqual(span.get_tag("request_id"), None)
         self.assertEqual(span.get_tag("span_type"), "inferred")
-        # TODO FIXME: investigate why this is flaky
-        # self.assertEqual(span.start, 1636004265.0)
+        self.assertEqual(span.start, 1635989865.0)
         self.assertEqual(span.span_type, "web")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
`strftime` takes machine's timezone into account when calculating seconds elapsed since timezone. This means tests fail when running on a machine with non UTC timezone. Updated to use UTC timezone explicitly and use timestamp to get seconds elapsed since epoch. 

### Motivation

<!--- What inspired you to submit this pull request? --->
Testcases failing on local machine but passing in docker container (or vice versa, depending on expected value).

### Testing Guidelines

<!--- How did you test this pull request? --->
`poetry run nose2 tests.test_tracing.TestInferredSpans`

`./scripts/run_tests.sh`

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
