### PR TITLE
Fix repository typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The Datadog AWS Lambda Library"
 authors = ["Datadog, Inc. <dev@datadoghq.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/DataDog/datadog-lambda-pyhon"
+repository = "https://github.com/DataDog/datadog-lambda-python"
 keywords = [
     "datadog",
     "aws",


### PR DESCRIPTION
### What does this PR do?

Fixes the repository URL in pyroject.toml, so that [the package on docs sites like pypi.org](https://pypi.org/project/datadog-lambda/) can link to the proper repo.

### Motivation

I clicked the repository URL in pypi.org and it 404. 🙂 

### Testing Guidelines

I think this might need to be released for a change to happen in the docs site, but this is a minor typo fix so shouldn't be risky.

### Additional Notes

None.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
