### PR TITLE
fix: Support Decimal for tag_object

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         run: sudo yarn global add serverless@^2.72.2 --prefix /usr/local
       - name: Install Crossbuild Deps
         run: |
-          sudo apt-get update --allow-releaseinfo-change
+          sudo apt-get update --allow-releaseinfo-change --fix-missing
           sudo apt install -y qemu-user-static binfmt-support
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         run: sudo yarn global add serverless@^2.72.2 --prefix /usr/local
       - name: Install Crossbuild Deps
         run: |
-          sudo apt-get update
+          sudo apt-get update --allow-releaseinfo-change
           sudo apt install -y qemu-user-static binfmt-support
 
       - name: Install dependencies

--- a/.github/workflows/check-size.yml
+++ b/.github/workflows/check-size.yml
@@ -15,7 +15,9 @@ jobs:
           python-version: 3.7
 
       - name: Install Crossbuild Deps
-        run: sudo apt install -y qemu-user-static binfmt-support
+        run: |
+          sudo apt-get update --allow-releaseinfo-change --fix-missing
+          sudo apt install -y qemu-user-static binfmt-support
 
       - name: Install dependencies
         run: |

--- a/datadog_lambda/tag_object.py
+++ b/datadog_lambda/tag_object.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+from decimal import Decimal
 import json
 import logging
 
@@ -26,7 +27,7 @@ def tag_object(span, key, obj, depth=0):
         except ValueError:
             redacted = _redact_val(key, obj[0:5000])
             return span.set_tag(key, redacted)
-    if isinstance(obj, int) or isinstance(obj, float):
+    if isinstance(obj, int) or isinstance(obj, float) or isinstance(obj, Decimal):
         return span.set_tag(key, obj)
     if isinstance(obj, list):
         for k, v in enumerate(obj):

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -85,14 +85,9 @@ class TestTagObject(unittest.TestCase):
         )
 
     def test_decimal_tag_object(self):
-        payload = {
-            "myValue": Decimal(500.50)
-        }
+        payload = {"myValue": Decimal(500.50)}
         spanMock = MagicMock()
         tag_object(spanMock, "function.request", payload)
         spanMock.set_tag.assert_has_calls(
-            [
-                call("function.request.myValue", Decimal(500.50)),
-            ],
-            True,
+            [call("function.request.myValue", Decimal(500.50)),], True,
         )

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -1,4 +1,5 @@
 import unittest
+from decimal import Decimal
 
 try:
     from unittest.mock import MagicMock, patch, call
@@ -79,6 +80,19 @@ class TestTagObject(unittest.TestCase):
                 call("function.request.jsonString.stringifyThisJson.0.here", "is"),
                 call("function.request.jsonString.stringifyThisJson.0.an", "object"),
                 call("function.request.jsonString.stringifyThisJson.0.number", 1),
+            ],
+            True,
+        )
+
+    def test_decimal_tag_object(self):
+        payload = {
+            "myValue": Decimal(500.50)
+        }
+        spanMock = MagicMock()
+        tag_object(spanMock, "function.request", payload)
+        spanMock.set_tag.assert_has_calls(
+            [
+                call("function.request.myValue", Decimal(500.50)),
             ],
             True,
         )

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -89,5 +89,8 @@ class TestTagObject(unittest.TestCase):
         spanMock = MagicMock()
         tag_object(spanMock, "function.request", payload)
         spanMock.set_tag.assert_has_calls(
-            [call("function.request.myValue", Decimal(500.50)),], True,
+            [
+                call("function.request.myValue", Decimal(500.50)),
+            ],
+            True,
         )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
`decimal.Decimal` is an `object`, but that throws an error as it's not iterable.
This PR fixes that.

### Motivation`

Fixes #213

### Testing Guidelines

Covered by automated tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
