### PR TITLE
Relax datadog version requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -356,7 +356,7 @@ dev = ["boto3", "requests", "nose2", "flake8", "httpretty"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.0,<4"
-content-hash = "48c6e38b716b2ce193af0ffb0430a159c6ba7e0acce29be0a07289a91adeea73"
+content-hash = "ca4755fbb4131d3113797f829d9b3423e7d4b44bf756d5aed1fe3af2d475c376"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.6.0,<4"
-datadog = "^0.41.0"
+datadog = "^0.41"
 wrapt = "^1.11.2"
 ddtrace = "^0.61.1"
 importlib_metadata = {version = "^1.0", python = "<3.8"}


### PR DESCRIPTION
### What does this PR do?

The use of the [caret requirement](https://python-poetry.org/docs/dependency-specification/) with a pre-1.0 package is effectively locking the `datadog` package to a single version.

This PR proposes allowing more recent versions of the `datadog` package (e.g., 0.42.0, 0.43.0, etc).

### Motivation

I am trying to use this package in tandem with a different package that requires `datadog >= 0.42.0`. But this package has effectively locked `datadog` to `0.41.0` so they are currently not compatible.

### Testing Guidelines

Changes are only to package requirements.

### Additional Notes

Let me know if there are better ways to tackle this issue.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
