### PR TITLE
Aj/swap list with dict

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -332,7 +332,7 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
             parent_id,
             sampling_priority,
         ) = extract_context_custom_extractor(extractor, event, lambda_context)
-    elif isinstance(event, (list, dict)) and "headers" in event:
+    elif isinstance(event, (set, dict)) and "headers" in event:
         (
             trace_id,
             parent_id,

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -332,7 +332,7 @@ def extract_dd_trace_context(event, lambda_context, extractor=None):
             parent_id,
             sampling_priority,
         ) = extract_context_custom_extractor(extractor, event, lambda_context)
-    elif "headers" in event:
+    elif isinstance(event, (list, dict)) and "headers" in event:
         (
             trace_id,
             parent_id,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -103,7 +103,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
 
     def test_with_non_object_event(self):
         lambda_ctx = get_mock_context()
-        ctx, source = extract_dd_trace_context(b'', lambda_ctx)
+        ctx, source = extract_dd_trace_context(b"", lambda_ctx)
         self.assertEqual(source, "xray")
         self.assertDictEqual(
             ctx,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -101,6 +101,28 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             {},
         )
 
+    def test_with_non_object_event(self):
+        lambda_ctx = get_mock_context()
+        ctx, source = extract_dd_trace_context(b'', lambda_ctx)
+        self.assertEqual(source, "xray")
+        self.assertDictEqual(
+            ctx,
+            {
+                "trace-id": fake_xray_header_value_root_decimal,
+                "parent-id": fake_xray_header_value_parent_decimal,
+                "sampling-priority": "2",
+            },
+        )
+        self.assertDictEqual(
+            get_dd_trace_context(),
+            {
+                TraceHeader.TRACE_ID: fake_xray_header_value_root_decimal,
+                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
+                TraceHeader.SAMPLING_PRIORITY: "2",
+            },
+            {},
+        )
+
     def test_with_incomplete_datadog_trace_headers(self):
         lambda_ctx = get_mock_context()
         ctx, source = extract_dd_trace_context(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

We don't know what a user may bring to the `event` arg, as libraries ran before us (see #225) can rewrite it.
Although `list` responds to `in`, it wouldn't really let us access headers unless we knew the format of the list. But a set will, so this PR allows for a set instead, which does work with the underlying calls in `extract_context_from_http_event_or_context`

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
