### PR TITLE
Add debugging log for metric sent to extension

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -53,7 +53,9 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
     tags = tag_dd_lambda_layer(tags)
 
     if should_use_extension:
-        logger.debug("Sending metric %s value %s to Datadog via extension", metric_name, value)
+        logger.debug(
+            "Sending metric %s value %s to Datadog via extension", metric_name, value
+        )
         lambda_stats.distribution(metric_name, value, tags=tags, timestamp=timestamp)
     else:
         if flush_to_logs or force_async:

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -53,6 +53,7 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
     tags = tag_dd_lambda_layer(tags)
 
     if should_use_extension:
+        logger.debug("Sending metric %s value %s to Datadog via extension", metric_name, value)
         lambda_stats.distribution(metric_name, value, tags=tags, timestamp=timestamp)
     else:
         if flush_to_logs or force_async:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add debugging log for metric sent to extension.

### Motivation

Helps narrow down issues between the runtime (customer code or this lambda library) and the extension when metrics are missing.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
