### PR TITLE
Fix error when APIGateway headers are None

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -174,7 +174,7 @@ def extract_context_from_http_event_or_context(event, lambda_context):
 
     Falls back to lambda context if no trace data is found in the `headers`
     """
-    headers = event.get("headers", {})
+    headers = event.get("headers", {}) or {}
     lowercase_headers = {k.lower(): v for k, v in headers.items()}
 
     trace_id = lowercase_headers.get(TraceHeader.TRACE_ID)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -182,7 +182,6 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
         )
 
-
     def test_with_extractor_function(self):
         def extractor_foo(event, context):
             foo = event.get("foo", {})
@@ -1239,13 +1238,10 @@ class TestInferredSpans(unittest.TestCase):
         mock_submit_errors_metric.assert_called_once()
         self.assertEqual(1, mock_span.error)
 
-
     def test_no_error_with_nonetype_headers(self):
         lambda_ctx = get_mock_context()
         ctx, source = extract_dd_trace_context(
-            {
-                "headers": None
-            },
+            {"headers": None},
             lambda_ctx,
         )
         self.assertEqual(ctx, None)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -182,6 +182,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
         )
 
+
     def test_with_extractor_function(self):
         def extractor_foo(event, context):
             foo = event.get("foo", {})
@@ -1237,3 +1238,14 @@ class TestInferredSpans(unittest.TestCase):
         )
         mock_submit_errors_metric.assert_called_once()
         self.assertEqual(1, mock_span.error)
+
+
+    def test_no_error_with_nonetype_headers(self):
+        lambda_ctx = get_mock_context()
+        ctx, source = extract_dd_trace_context(
+            {
+                "headers": None
+            },
+            lambda_ctx,
+        )
+        self.assertEqual(ctx, None)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes https://github.com/DataDog/datadog-lambda-python/issues/249 by allowing context["headers"] to be None and falling back to an empty {}

### Motivation
https://github.com/DataDog/datadog-lambda-python/issues/249

### Testing Guidelines
Passes tests and added another for this case

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
