### PR TITLE
SLS-2757: Modify PyPI to use token for publishing

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -37,7 +37,7 @@ AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 aws-vault exec prod-engineering -- aws sts get-caller-identity
 
 # Ensure pypi registry access
-read -p "Do you have the PyPi login credentials for datadog account (y/n)?" CONT
+read -p "Do you have access to the serverless shared vault in 1Password (y/n)?" CONT
 if [ "$CONT" != "y" ]; then
     echo "Exiting"
     exit 1

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -37,7 +37,7 @@ AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 aws-vault exec prod-engineering -- aws sts get-caller-identity
 
 # Ensure pypi registry access
-read -p "Do you have access to the serverless shared vault in 1Password (y/n)?" CONT
+read -p "Do you have access to PyPI (y/n)?" CONT
 if [ "$CONT" != "y" ]; then
     echo "Exiting"
     exit 1

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -14,6 +14,9 @@ if [ -d "dist" ]; then
     rm -rf dist;
 fi
 
-# Publish to pypi
-poetry publish --build
+echo "Please enter the PyPI token (password) for datadog-lambda-python"
+echo "This can be found in 1password under the shared-serverless vault"
+read -p "Token name: " TOKEN
 
+# Publish to pypi
+poetry publish --build --username __token__ --password $TOKEN


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Changes PyPI auth method to token instead of Datadog account.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Tested manually --dry-run flag.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
