### PR TITLE
Handle a custom `detail` field in Lambda event payloads

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -138,8 +138,8 @@ def parse_event_source(event: dict) -> _EventSource:
         event_source = _EventSource(EventTypes.EVENTBRIDGE)
 
     event_detail = event.get("detail")
-    cw_event_categories = event_detail and event_detail.get("EventCategories")
-    if event.get("source") == "aws.events" or cw_event_categories:
+    has_event_categories = isinstance(event_detail, dict) and event_detail.get("EventCategories") is not None
+    if event.get("source") == "aws.events" or has_event_categories:
         event_source = _EventSource(EventTypes.CLOUDWATCH_EVENTS)
 
     event_record = get_first_record(event)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
We don't check that the `detail` field in an event payload is a dict prior to calling `.get()` on it. Custom invocation events are common and so are generic names like `detail` so we should handle with care.

### Motivation

<!--- What inspired you to submit this pull request? --->
#275 

### Testing Guidelines

<!--- How did you test this pull request? --->
Attempted to reproduce the issue

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
