### PR TITLE
build: relax `datadog` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.0,<4"
-datadog = "^0.41"
+datadog = ">=0.41.0,<1.0.0"
 wrapt = "^1.11.2"
 ddtrace = "^1.6.4"
 importlib_metadata = {version = "^1.0", python = "<3.8"}


### PR DESCRIPTION
### What does this PR do?

Relaxing the `datadog` version requirement.

### Motivation

It seems to me that the version is not intentionally locked to the range `>= 0.41, < 0.42`, and it is more a matter of the fact that `poetry` treats versions that start with `0` differently when using `^` ([docs](https://python-poetry.org/docs/dependency-specification/#caret-requirements))

### Testing Guidelines

Releases of the `datadog` lib (it looks to me that there is no risk):
- https://github.com/DataDog/datadogpy/releases

### Additional Notes

Related issue:
- https://github.com/DataDog/datadog-lambda-python/issues/253

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
