### PR TITLE
issue 295

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -345,6 +345,20 @@ def extract_context_custom_extractor(extractor, event, lambda_context):
         return None, None, None
 
 
+def is_authorizer_response(response) -> bool:
+    try:
+        return (
+            response is not None
+            and response["principalId"]
+            and response["policyDocument"]
+        )
+    except KeyError:
+        pass
+    except Exception as e:
+        logger.debug("unknown error while checking is_authorizer_response %s", e)
+    return False
+
+
 def get_injected_authorizer_data(event, is_http_api) -> dict:
     try:
         authorizer_headers = event.get("requestContext", {}).get("authorizer")

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -37,6 +37,7 @@ from datadog_lambda.tracing import (
     create_function_execution_span,
     create_inferred_span,
     InferredSpanInfo,
+    is_authorizer_response,
 )
 from datadog_lambda.trigger import (
     extract_trigger_tags,
@@ -280,12 +281,7 @@ class _LambdaDecorator(object):
             if should_use_extension:
                 flush_extension()
 
-            if (
-                self.encode_authorizer_context
-                and self.response
-                and self.response.get("principalId")
-                and self.response.get("policyDocument")
-            ):
+            if self.encode_authorizer_context and is_authorizer_response(self.response):
                 self._inject_authorizer_span_headers(
                     event.get("requestContext", {}).get("requestId")
                 )

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -544,3 +544,17 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.assertEquals(inject_data[TraceHeader.TRACE_ID], "456")
         self.assertEquals(inject_data[TraceHeader.SAMPLING_PRIORITY], "1")
         self.assertEquals(result["context"]["scope"], "still here")
+
+    @patch("traceback.print_exc")
+    def test_different_return_type_no_error(self, MockPrintExc):
+        TEST_RESULTS = ["a str to return", 42, {"value": 42}, ["A", 42], None]
+        mock_context = get_mock_context()
+        for test_result in TEST_RESULTS:
+
+            @datadog_lambda_wrapper
+            def return_type_test(event, context):
+                return test_result
+
+            result = return_type_test({}, mock_context)
+            self.assertEquals(result, test_result)
+            self.assertFalse(MockPrintExc.called)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- First added a unittest case to replicate the issue
- Add the `is_authorizer_response` helper method to duck-type the response in a pythonic way.

### Motivation

Fix the issue that the str responses were not handled elegantly and causing `traceback.print_exc` 

### Testing Guidelines

Added a test case to make sure no matter the response type, no error thrown and no traceback.print_exe in normal case.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
