### PR TITLE
Lambda and Step Functions Span Linking

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -330,8 +330,8 @@ def extract_context_from_kinesis_event(event, lambda_context):
 
 def _deterministic_md5_hash(s: str) -> str:
     """MD5 here is to generate trace_id, not for any encryption."""
-    hex = hashlib.md5(s.encode("ascii")).hexdigest()
-    binary = bin(int(hex, 16))
+    hex_number = hashlib.md5(s.encode("ascii")).hexdigest()
+    binary = bin(int(hex_number, 16))
     binary_str = str(binary)
     binary_str_remove_0b = binary_str[2:].rjust(128, "0")
     most_significant_64_bits_without_leading_1 = "0" + binary_str_remove_0b[1:-64]

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -350,7 +350,6 @@ def extract_context_from_step_functions(event, lambda_context):
         execution_id = event.get("Execution").get("Id")
         state_name = event.get("State").get("Name")
         state_entered_time = event.get("State").get("EnteredTime")
-
         trace_id = _deterministic_md5_hash(execution_id)
         parent_id = _deterministic_md5_hash(
             execution_id + "#" + state_name + "#" + state_entered_time

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -34,12 +34,13 @@ class EventTypes(_stringTypedEnum):
     CLOUDWATCH_EVENTS = "cloudwatch-events"
     CLOUDFRONT = "cloudfront"
     DYNAMODB = "dynamodb"
+    EVENTBRIDGE = "eventbridge"
     KINESIS = "kinesis"
     LAMBDA_FUNCTION_URL = "lambda-function-url"
     S3 = "s3"
     SNS = "sns"
     SQS = "sqs"
-    EVENTBRIDGE = "eventbridge"
+    STEPFUNCTIONS = "states"
 
 
 class EventSubtypes(_stringTypedEnum):

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -146,6 +146,9 @@ def parse_event_source(event: dict) -> _EventSource:
     if event.get("source") == "aws.events" or has_event_categories:
         event_source = _EventSource(EventTypes.CLOUDWATCH_EVENTS)
 
+    if "Execution" in event and "StateMachine" in event and "State" in event:
+        event_source = _EventSource(EventTypes.STEPFUNCTIONS)
+
     event_record = get_first_record(event)
     if event_record:
         aws_event_source = event_record.get(

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock, patch, call
 
 import ddtrace
 
-# from ddtrace.constants import ERROR_MSG, ERROR_TYPE
+from ddtrace.constants import ERROR_MSG, ERROR_TYPE
 from ddtrace import tracer
 from ddtrace.context import Context
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1402,3 +1402,11 @@ class TestStepFunctionsTraceContext(unittest.TestCase):
             ":c8baf081-31f1-464d-971f-70cb17d01111#step-one#2022-12-08T21:08:19.224Z"
         )
         self.assertEqual("8034507082463708833", result)
+
+    def test_deterministic_m5_hash__always_leading_with_zero(self):
+        for i in range(100):
+            result = _deterministic_md5_hash(str(i))
+            result_in_binary = bin(int(result))
+            # Leading zeros will be omitted, so only test for full 64 bits present
+            if len(result_in_binary) == 66:  # "0b" + 64 bits.
+                self.assertTrue(result_in_binary.startswith("0b0"))

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, Mock, patch, call
 
 import ddtrace
 
-from ddtrace.constants import ERROR_MSG, ERROR_TYPE
 from ddtrace import tracer
 from ddtrace.context import Context
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
To link Lambda span that are triggered by Step Functions with Step Functions span.

https://datadoghq.atlassian.net/browse/SLS-3333

### What does this PR do?
This PR sets `trace_id` and `parent_id` when Step Functions Context Object is detected in the Lambda handler's `event` dictionary. The hashing function is implemented as backend and [dd-lambda-js](https://github.com/DataDog/datadog-lambda-js/pull/331).

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Tested in sandbox account ([trace link](https://ddserverless.datadoghq.com/apm/traces?query=%40_trace_root%3A1%20resource_name%3Apy-span-linking%20&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=1063614699821071255&spanType=trace-root&spanViewType=metadata&timeHint=1681242079707&trace=AgAAAYdx1kHbT2XGUAAAAAAAAAAYAAAAAEFZZHgxbXJEQUFBTndhOHBhdDZjdEtkcgAAACQAAAAAMDE4NzcxZDctNzY5Ni00ZjRjLWE4NTgtYzQyZTdjMzNmMjgw&traceID=7757299778823358422&start=1681240673321&end=1681242473321&paused=false)).

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/47579703/231272175-ec9996e2-8586-4c8d-9876-c3f9ee4f32d0.png">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
