### PR TITLE
feat: Strip DD WAF from Lambda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.
 RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
+RUN rm -rf ./python/lib/$runtime/site-packages/ddtrace/appsec

--- a/tests/integration/serverless.yml
+++ b/tests/integration/serverless.yml
@@ -12,6 +12,7 @@ provider:
     DD_API_KEY: ${env:DD_API_KEY}
     DD_TRACE_MANAGED_SERVICES: true
     DD_COLD_START_TRACING: false
+    DD_APPSEC_ENABLED: false
   timeout: 15
   deploymentBucket:
     name: integration-tests-serververless-deployment-bucket


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

DD AppSec for Serverless is performed in the extension, not in the tracer. So we can strip this.

Blocked by: https://github.com/DataDog/dd-trace-py/pull/5538

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
