### PR TITLE
feat: Strip setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.
 RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
+RUN rm -rf ./python/lib/$runtime/site-packages/setuptools


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

setuptools contains binaries for every major architecture, but it's already included in the lambda runtime, so we don't need it.

I found this by pulling the python base images and running an interpreter, finding that `setuptools` is resolved just fine:

```
✗ docker run -it --entrypoint sh  public.ecr.aws/lambda/python:3.10
sh-4.2# python
Python 3.10.9 (main, Mar 31 2023, 16:38:53) [GCC 7.3.1 20180712 (Red Hat 7.3.1-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>>import os.path
>>>import setuptools

>>> print(os.path.abspath(setuptools.__file__))
/var/lang/lib/python3.10/site-packages/setuptools/__init__.py
>>>

```

TODO - need to verify that the provided version doesn't conflict with our own, need to verify that dd-trace-py source code integration still works with this stripped. But integration tests pass and that's a very good sign.

Should save us 3mb.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
