### PR TITLE
Some env variables depend on DD_TRACE_ENABLED

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -122,16 +122,17 @@ class _LambdaDecorator(object):
             self.trace_extractor = None
             self.span = None
             self.inferred_span = None
-            self.make_inferred_span = (
+            depends_on_dd_tracing_enabled = lambda original_boolean : dd_tracing_enabled and original_boolean
+            self.make_inferred_span = depends_on_dd_tracing_enabled(
                 os.environ.get("DD_TRACE_MANAGED_SERVICES", "true").lower() == "true"
             )
-            self.encode_authorizer_context = (
+            self.encode_authorizer_context = depends_on_dd_tracing_enabled(
                 os.environ.get("DD_ENCODE_AUTHORIZER_CONTEXT", "true").lower() == "true"
             )
-            self.decode_authorizer_context = (
+            self.decode_authorizer_context = depends_on_dd_tracing_enabled(
                 os.environ.get("DD_DECODE_AUTHORIZER_CONTEXT", "true").lower() == "true"
             )
-            self.cold_start_tracing = (
+            self.cold_start_tracing = depends_on_dd_tracing_enabled(
                 os.environ.get("DD_COLD_START_TRACING", "true").lower() == "true"
             )
             self.min_cold_start_trace_duration = 3


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Make some env variables depend on `DD_TRACE_ENABLED`, i.e. all False if `DD_TRACE_ENABLED` set to False: 
`DD_COLD_START_TRACING` for cold start aws.lambda.import spans
`DD_TRACE_MANAGED_SERVICES` for inferred spans
`DD_DECODE_AUTHORIZER_CONTEXT` and `DD_ENCODE_AUTHORIZER_CONTEXT` for lambda authorizor spans (a special case for inferred spans)

### Motivation

The features controlled by these env variables are all part of DD Tracing...

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
