### PR TITLE
fix: Ensure authorized span headers are injected as `str`

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -219,7 +219,7 @@ class _LambdaDecorator(object):
         injected_headers[Headers.Parent_Span_Finish_Time] = finish_time_ns
         if request_id is not None:
             injected_headers[Headers.Authorizing_Request_Id] = request_id
-        datadog_data = base64.b64encode(json.dumps(injected_headers).encode())
+        datadog_data = base64.b64encode(json.dumps(injected_headers).encode()).decode()
         self.response.setdefault("context", {})
         self.response["context"]["_datadog"] = datadog_data
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -539,7 +539,9 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         lambda_handler.inferred_span = mock_span
 
         result = lambda_handler(lambda_event, lambda_context)
-        inject_data = json.loads(base64.b64decode(result["context"]["_datadog"]))
+        raw_inject_data = result["context"]["_datadog"]
+        self.assertIsInstance(raw_inject_data, str)
+        inject_data = json.loads(base64.b64decode(raw_inject_data))
         self.assertEquals(inject_data[TraceHeader.PARENT_ID], "123")
         self.assertEquals(inject_data[TraceHeader.TRACE_ID], "456")
         self.assertEquals(inject_data[TraceHeader.SAMPLING_PRIORITY], "1")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

It injects the authorizer span headers as a regular string instead of a byte string.

### Motivation

The Python 3.7 lambda runtime can't serialize responses that contain byte strings.

### Testing Guidelines
### Additional Notes
### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
