### PR TITLE
[downsizing] remove jsonshema/tests dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,4 @@ RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete
 # installs it, while it's already provided by the Lambda Runtime.
 RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
 RUN rm -rf ./python/lib/$runtime/site-packages/setuptools
+RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove jsonshema's tests folder from the layer package.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

This was tested along with https://github.com/DataDog/datadog-lambda-python/pull/322

`jsonschema` is used by ddtrace when validate the sample rules (in json). The tests folder is never needed. 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
