### PR TITLE
set_correlation_ids should handle the empty context case

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -515,10 +515,12 @@ def get_dd_trace_context():
     automatically, but this function can be used to manually inject the trace
     context to an outgoing request.
     """
-    global dd_trace_context
+    if dd_tracing_enabled:
+        dd_trace_py_context = _get_dd_trace_py_context()
+        if dd_trace_py_context is not None:
+            return _context_obj_to_headers(dd_trace_py_context)
 
-    context = None
-    xray_context = None
+    global dd_trace_context
 
     try:
         xray_context = _get_xray_trace_context()  # xray (sub)segment
@@ -527,22 +529,20 @@ def get_dd_trace_context():
             "get_dd_trace_context couldn't read from segment from x-ray, with error %s"
             % e
         )
+    if not xray_context:
+        return {}
 
-    if xray_context and not dd_trace_context:
-        context = xray_context
-    elif xray_context and dd_trace_context:
-        context = dd_trace_context.copy()
-        context["parent-id"] = xray_context.get("parent-id")
-        logger.debug(
-            "Set parent id from xray trace context: %s", context.get("parent-id")
-        )
+    if not dd_trace_context:
+        return _context_obj_to_headers(xray_context)
 
-    if dd_tracing_enabled:
-        dd_trace_py_context = _get_dd_trace_py_context()
-        if dd_trace_py_context is not None:
-            context = dd_trace_py_context
 
-    return _context_obj_to_headers(context) if context is not None else {}
+    context = dd_trace_context.copy()
+    context["parent-id"] = xray_context.get("parent-id")
+    logger.debug(
+        "Set parent id from xray trace context: %s", context.get("parent-id")
+    )
+
+    return _context_obj_to_headers(context)
 
 
 def set_correlation_ids():
@@ -561,6 +561,8 @@ def set_correlation_ids():
         return
 
     context = get_dd_trace_context()
+    if not context:
+        return
 
     span = tracer.trace("dummy.span")
     span.trace_id = int(context[TraceHeader.TRACE_ID])

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -535,12 +535,9 @@ def get_dd_trace_context():
     if not dd_trace_context:
         return _context_obj_to_headers(xray_context)
 
-
     context = dd_trace_context.copy()
     context["parent-id"] = xray_context.get("parent-id")
-    logger.debug(
-        "Set parent id from xray trace context: %s", context.get("parent-id")
-    )
+    logger.debug("Set parent id from xray trace context: %s", context.get("parent-id"))
 
     return _context_obj_to_headers(context)
 

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -75,7 +75,6 @@ def generate_random_id():
 
 
 def build_segment(context, key, metadata):
-
     segment = json.dumps(
         {
             "id": generate_random_id(),

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -75,6 +75,7 @@ def generate_random_id():
 
 
 def build_segment(context, key, metadata):
+
     segment = json.dumps(
         {
             "id": generate_random_id(),

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -511,7 +511,7 @@ class TestLogsInjection(unittest.TestCase):
         span.finish()
 
     def test_set_correlation_ids_handle_empty_trace_context(self):
-        # neither x-ray or ddtrace is use. no tracing at all.
+        # neither x-ray or ddtrace is used. no tracing context at all.
         self.mock_get_dd_trace_context.return_value = {}
         # no exception thrown
         set_correlation_ids()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -483,6 +483,13 @@ class TestLogsInjection(unittest.TestCase):
         self.assertEqual(span.trace_id, 123)
         self.assertEqual(span.span_id, 456)
 
+    def test_set_correlation_ids_handle_empty_trace_context(self):
+        # neither x-ray or ddtrace is use. no tracing at all.
+        self.mock_get_dd_trace_context.return_value = {}
+        # no exception thrown
+        set_correlation_ids()
+        span = tracer.current_span()
+        self.assertIsNone(span)
 
 class TestFunctionSpanTags(unittest.TestCase):
     def test_function(self):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -491,6 +491,7 @@ class TestLogsInjection(unittest.TestCase):
         span = tracer.current_span()
         self.assertIsNone(span)
 
+
 class TestFunctionSpanTags(unittest.TestCase):
     def test_function(self):
         ctx = get_mock_context()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- When neither x-ray nor dd-trace is used, the tracing context should be {} and set_correlation_ids() should not break. That is , 
```python 
if not context:
    return
```
- Reorganized the code for `get_dd_trace_context` but **no logic change**.
 
<!--- A brief description of the change being made with this pull request. --->

### Motivation
https://github.com/DataDog/datadog-lambda-python/issues/332
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
