### PR TITLE
fix: unit tests failing due change in internals of tracer

### DIFF
--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -31,7 +31,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
     def setUp(self):
         # Force @datadog_lambda_wrapper to always create a real
         # (not no-op) wrapper.
-        patch("ddtrace.internal.remoteconfig.RemoteConfig").start()
+        patch("ddtrace.internal.remoteconfig.worker.RemoteConfigPoller").start()
         patch("ddtrace.internal.writer.AgentWriter.flush_queue").start()
 
         wrapper.datadog_lambda_wrapper._force_wrap = True


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates unit tests to not fail.

### Motivation

The Python tracer updated how Remote Configuration was implemented.
Learn more in [datadog/dd-trace-py#5464](https://github.com/DataDog/dd-trace-py/pull/5464).

### Testing Guidelines

n/a

### Additional Notes

This is going to be a problem if we keep relying on internals which can be updated at any time.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
