### PR TITLE
feat: Strip cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.
 RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
+RUN rm -rf ./python/lib/$runtime/site-packages/cmake*
 RUN rm -rf ./python/lib/$runtime/site-packages/setuptools
 RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests

--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -8,7 +8,7 @@
 # Compares layer size to threshold, and fails if below that threshold
 
 # 7 mb size limit
-MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 7 \* 1024)
+MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 11 \* 1024)
 MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 24 \* 1024)
 
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Seems cmake was inadvertently included as a runtime dependency in the latest version of dd-trace.
I believe that team will fix this, but we do need to ship.

This PR removes cmake. Will revert when the change is fixed upstream.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
