### PR TITLE
feat: support Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime-param: ['3.7', '3.8', '3.9', '3.10']
+        runtime-param: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Slack](https://chat.datadoghq.com/badge.svg?bg=632CA6)](https://chat.datadoghq.com/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-lambda-python/blob/main/LICENSE)
 
-Datadog Lambda Library for Python (3.7, 3.8, 3.9, and 3.10) enables [enhanced Lambda metrics](https://docs.datadoghq.com/serverless/enhanced_lambda_metrics), [distributed tracing](https://docs.datadoghq.com/serverless/distributed_tracing), and [custom metric submission](https://docs.datadoghq.com/serverless/custom_metrics) from AWS Lambda functions.
+Datadog Lambda Library for Python (3.7, 3.8, 3.9, 3.10, and 3.11) enables [enhanced Lambda metrics](https://docs.datadoghq.com/serverless/enhanced_lambda_metrics), [distributed tracing](https://docs.datadoghq.com/serverless/distributed_tracing), and [custom metric submission](https://docs.datadoghq.com/serverless/custom_metrics) from AWS Lambda functions.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [tool.poetry.dependencies]

--- a/scripts/add_new_region.sh
+++ b/scripts/add_new_region.sh
@@ -12,8 +12,8 @@ set -e
 
 OLD_REGION='us-east-1'
 
-LAYER_NAMES=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM")
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7" "python3.8" "python3.8" "python3.9" "python3.9" "python3.10" "python3.10")
+LAYER_NAMES=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7" "python3.8" "python3.8" "python3.9" "python3.9" "python3.10" "python3.10" "python3.11" "python3.11")
 NEW_REGION=$1
 
 publish_layer() {

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -14,7 +14,7 @@ set -e
 
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_py"
-AVAILABLE_PYTHON_VERSIONS=("3.7" "3.8" "3.9" "3.10")
+AVAILABLE_PYTHON_VERSIONS=("3.7" "3.8" "3.9" "3.10" "3.11")
 
 # Determine which Python versions to build layers for
 if [ -z "$PYTHON_VERSION" ]; then

--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -14,7 +14,7 @@ MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 24 \* 1024)
 
 LAYER_FILES_PREFIX="datadog_lambda_py"
 LAYER_DIR=".layers"
-VERSIONS=("3.7" "3.8" "3.9" "3.10")
+VERSIONS=("3.7" "3.8" "3.9" "3.10" "3.11")
 
 for version in "${VERSIONS[@]}"
 do

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM")
+LAYER_NAMES=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 LAYERS_MISSING_REGIONS=()
 

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -13,10 +13,10 @@ set -e
 # Makes sure any subprocesses will be terminated with this process
 trap "pkill -P $$; exit 1;" INT
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7" "python3.8" "python3.8" "python3.9" "python3.9" "python3.10" "python3.10")
-LAYER_PATHS=(".layers/datadog_lambda_py-amd64-3.7.zip" ".layers/datadog_lambda_py-amd64-3.8.zip" ".layers/datadog_lambda_py-arm64-3.8.zip" ".layers/datadog_lambda_py-amd64-3.9.zip" ".layers/datadog_lambda_py-arm64-3.9.zip" ".layers/datadog_lambda_py-amd64-3.10.zip" ".layers/datadog_lambda_py-arm64-3.10.zip")
-AVAILABLE_LAYERS=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM")
-ARCHS=("amd64" "amd64" "amd64""amd64" "amd64" "arm64" "amd64" "arm64")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7" "python3.8" "python3.8" "python3.9" "python3.9" "python3.10" "python3.10" "python3.11" "python3.11")
+LAYER_PATHS=(".layers/datadog_lambda_py-amd64-3.7.zip" ".layers/datadog_lambda_py-amd64-3.8.zip" ".layers/datadog_lambda_py-arm64-3.8.zip" ".layers/datadog_lambda_py-amd64-3.9.zip" ".layers/datadog_lambda_py-arm64-3.9.zip" ".layers/datadog_lambda_py-amd64-3.10.zip" ".layers/datadog_lambda_py-arm64-3.10.zip" ".layers/datadog_lambda_py-amd64-3.11.zip" ".layers/datadog_lambda_py-arm64-3.11.zip")
+AVAILABLE_LAYERS=("Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM")
+ARCHS=("amd64" "amd64" "amd64""amd64" "amd64" "arm64" "amd64" "arm64" "amd64" "arm64")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 # Check that the layer files exist

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -32,7 +32,7 @@ python37=("python3.7" "3.7" $(xxd -l 4 -c 4 -p < /dev/random))
 python38=("python3.8" "3.8" $(xxd -l 4 -c 4 -p < /dev/random))
 python39=("python3.9" "3.9" $(xxd -l 4 -c 4 -p < /dev/random))
 python310=("python3.10" "3.10" $(xxd -l 4 -c 4 -p < /dev/random))
-python310=("python3.11" "3.11" $(xxd -l 4 -c 4 -p < /dev/random))
+python311=("python3.11" "3.11" $(xxd -l 4 -c 4 -p < /dev/random))
 
 PARAMETERS_SETS=("python37" "python38" "python39" "python310" "python311")
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -11,7 +11,7 @@ set -e
 # These values need to be in sync with serverless.yml, where there needs to be a function
 # defined for every handler_runtime combination
 LAMBDA_HANDLERS=("async-metrics" "sync-metrics")
-RUNTIMES=("python37" "python38" "python39" "python310")
+RUNTIMES=("python37" "python38" "python39" "python310" "python311")
 
 LOGS_WAIT_SECONDS=20
 
@@ -32,8 +32,9 @@ python37=("python3.7" "3.7" $(xxd -l 4 -c 4 -p < /dev/random))
 python38=("python3.8" "3.8" $(xxd -l 4 -c 4 -p < /dev/random))
 python39=("python3.9" "3.9" $(xxd -l 4 -c 4 -p < /dev/random))
 python310=("python3.10" "3.10" $(xxd -l 4 -c 4 -p < /dev/random))
+python310=("python3.11" "3.11" $(xxd -l 4 -c 4 -p < /dev/random))
 
-PARAMETERS_SETS=("python37" "python38" "python39" "python310")
+PARAMETERS_SETS=("python37" "python38" "python39" "python310" "python311")
 
 if [ -z "$RUNTIME_PARAM" ]; then
     echo "Python version not specified, running for all python versions."

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,7 +8,7 @@
 # Run unit tests in Docker
 set -e
 
-PYTHON_VERSIONS=("3.7" "3.8" "3.9" "3.10")
+PYTHON_VERSIONS=("3.7" "3.8" "3.9" "3.10" "3.11")
 
 for python_version in "${PYTHON_VERSIONS[@]}"
 do

--- a/scripts/sign_layers.sh
+++ b/scripts/sign_layers.sh
@@ -16,6 +16,8 @@ LAYER_FILES=(
     "datadog_lambda_py-arm64-3.9.zip"
     "datadog_lambda_py-amd64-3.10.zip"
     "datadog_lambda_py-arm64-3.10.zip"
+    "datadog_lambda_py-amd64-3.11.zip"
+    "datadog_lambda_py-arm64-3.11.zip"
 )
 SIGNING_PROFILE_NAME="DatadogLambdaSigningProfile"
 

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -1,0 +1,1471 @@
+INIT_START Runtime Version: python:3.11.vX	Runtime Version ARN: arn:aws:lambda:eu-west-1:XXXX:eu-west-1
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:true",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.us-east-2.amazonaws.com",
+        "resource": "GET /",
+        "name": "aws.apigateway",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.apigateway.rest",
+          "http.url": "XXXX.execute-api.us-east-2.amazonaws.com/",
+          "endpoint": "/",
+          "http.method": "GET",
+          "resource_names": "GET /",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "Prod",
+          "request_id": "XXXX",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "true",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX",
+          "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
+          "http.url_details.path": "/Prod/",
+          "http.method": "GET",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "dynamodb",
+        "resource": "ExampleTableWithStream",
+        "name": "aws.dynamodb",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.dynamodb",
+          "resource_names": "ExampleTableWithStream",
+          "tablename": "ExampleTableWithStream",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+          "event_id": "XXXX",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "stream_view_type": "NEW_AND_OLD_IMAGES",
+          "size_bytes": "26",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "eventbridge",
+        "resource": "eventbridge.custom.event.sender",
+        "name": "aws.eventbridge",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.eventbridge",
+          "resource_names": "eventbridge.custom.event.sender",
+          "detail_type": "testdetail",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "eventbridge"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.eu-west-1.amazonaws.com",
+        "resource": "GET /httpapi/get",
+        "name": "aws.httpapi",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.httpapi",
+          "endpoint": "/httpapi/get",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
+          "http.method": "GET",
+          "http.protocol": "HTTP/1.1",
+          "http.source_ip": "XXXX",
+          "http.user_agent": "XXXX/7.64.1",
+          "resource_names": "GET /httpapi/get",
+          "request_id": "XXXX",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "$default",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX$default",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
+          "http.url_details.path": "/httpapi/get",
+          "http.method": "GET",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "kinesis",
+        "resource": "EXAMPLE",
+        "name": "aws.kinesis",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.kinesis",
+          "resource_names": "EXAMPLE",
+          "streamname": "EXAMPLE",
+          "shardid": "shardId-XXXX",
+          "event_source_arn": "arn:aws:kinesis:EXAMPLE",
+          "event_id": "XXXX",
+          "event_name": "aws:kinesis:record",
+          "event_version": "1.0",
+          "partition_key": "XXXX",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "kinesis",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "s3",
+        "resource": "example-bucket",
+        "name": "aws.s3",
+        "error": 0,
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.s3",
+          "resource_names": "example-bucket",
+          "event_name": "ObjectCreated:Put",
+          "bucketname": "example-bucket",
+          "bucket_arn": "arn:aws:s3:::example-bucket",
+          "object_key": "test/key",
+          "object_size": "1024",
+          "object_etag": "XXXX",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "sns",
+        "resource": "sns-lambda",
+        "name": "aws.sns",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
+          "message_id": "XXXX",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "sqs",
+        "resource": "my-queue",
+        "name": "aws.sqs",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-async-metrics_python311",
+    "resource:integration-tests-python-XXXX-async-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "hello.dog",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "team:serverless",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+{
+  "m": "tests.integration.count",
+  "v": 21,
+  "e": XXXX,
+  "t": [
+    "test:integration",
+    "role:hello",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.eu-west-1.amazonaws.com",
+        "resource": "$default",
+        "name": "aws.apigateway.websocket",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.apigateway.websocket",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com$default",
+          "endpoint": "$default",
+          "resource_names": "$default",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "dev",
+          "request_id": "XXXX",
+          "connection_id": "XXXX=",
+          "event_type": "MESSAGE",
+          "message_direction": "IN",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-async-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-async-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-async-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-async-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -68,8 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -128,7 +127,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -154,7 +152,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -235,8 +232,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -291,7 +287,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -317,7 +312,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -392,8 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -447,7 +440,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -473,7 +465,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -558,8 +549,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -618,7 +608,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -644,7 +633,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -725,8 +713,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -781,7 +768,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -807,7 +793,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -885,8 +870,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -941,7 +925,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -967,7 +950,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1046,8 +1028,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1102,7 +1083,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1128,7 +1108,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1206,8 +1185,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1262,7 +1240,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1288,7 +1265,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1372,8 +1348,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1430,7 +1405,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1456,7 +1430,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -1,0 +1,1642 @@
+INIT_START Runtime Version: python:3.11.vX	Runtime Version ARN: arn:aws:lambda:eu-west-1:XXXX:eu-west-1
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:true",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.us-east-2.amazonaws.com",
+        "resource": "GET /",
+        "name": "aws.apigateway",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.apigateway.rest",
+          "http.url": "XXXX.execute-api.us-east-2.amazonaws.com/",
+          "endpoint": "/",
+          "http.method": "GET",
+          "resource_names": "GET /",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "Prod",
+          "request_id": "XXXX",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "true",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX",
+          "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
+          "http.url_details.path": "/Prod/",
+          "http.method": "GET",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms (init: XXXX ms) Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "dynamodb",
+        "resource": "ExampleTableWithStream",
+        "name": "aws.dynamodb",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.dynamodb",
+          "resource_names": "ExampleTableWithStream",
+          "tablename": "ExampleTableWithStream",
+          "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+          "event_id": "XXXX",
+          "event_name": "INSERT",
+          "event_version": "1.1",
+          "stream_view_type": "NEW_AND_OLD_IMAGES",
+          "size_bytes": "26",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "dynamodb",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "eventbridge",
+        "resource": "eventbridge.custom.event.sender",
+        "name": "aws.eventbridge",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.eventbridge",
+          "resource_names": "eventbridge.custom.event.sender",
+          "detail_type": "testdetail",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "eventbridge"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.eu-west-1.amazonaws.com",
+        "resource": "GET /httpapi/get",
+        "name": "aws.httpapi",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.httpapi",
+          "endpoint": "/httpapi/get",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
+          "http.method": "GET",
+          "http.protocol": "HTTP/1.1",
+          "http.source_ip": "XXXX",
+          "http.user_agent": "XXXX/7.64.1",
+          "resource_names": "GET /httpapi/get",
+          "request_id": "XXXX",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "$default",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX$default",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
+          "http.url_details.path": "/httpapi/get",
+          "http.method": "GET",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "kinesis",
+        "resource": "EXAMPLE",
+        "name": "aws.kinesis",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.kinesis",
+          "resource_names": "EXAMPLE",
+          "streamname": "EXAMPLE",
+          "shardid": "shardId-XXXX",
+          "event_source_arn": "arn:aws:kinesis:EXAMPLE",
+          "event_id": "XXXX",
+          "event_name": "aws:kinesis:record",
+          "event_version": "1.0",
+          "partition_key": "XXXX",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "kinesis",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "s3",
+        "resource": "example-bucket",
+        "name": "aws.s3",
+        "error": 0,
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.s3",
+          "resource_names": "example-bucket",
+          "event_name": "ObjectCreated:Put",
+          "bucketname": "example-bucket",
+          "bucket_arn": "arn:aws:s3:::example-bucket",
+          "object_key": "test/key",
+          "object_size": "1024",
+          "object_etag": "XXXX",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "s3",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "sns",
+        "resource": "sns-lambda",
+        "name": "aws.sns",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.sns",
+          "resource_names": "sns-lambda",
+          "topicname": "sns-lambda",
+          "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
+          "message_id": "XXXX",
+          "type": "Notification",
+          "subject": "TestInvoke",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "sns",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "sqs",
+        "resource": "my-queue",
+        "name": "aws.sqs",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.sqs",
+          "resource_names": "my-queue",
+          "queuename": "my-queue",
+          "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
+          "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+          "sender_id": "AIDAIENQZJOLO23YVJ4VO",
+          "_inferred_span.synchronicity": "async",
+          "_inferred_span.tag_source": "self",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "sqs",
+          "function_trigger.event_source_arn": "XXXX"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB
+START
+{
+  "m": "aws.lambda.enhanced.invocations",
+  "v": 1,
+  "e": XXXX,
+  "t": [
+    "region:eu-west-1",
+    "account_id:XXXX",
+    "functionname:integration-tests-python-XXXX-sync-metrics_python311",
+    "resource:integration-tests-python-XXXX-sync-metrics_python311",
+    "cold_start:false",
+    "memorysize:1024",
+    "runtime:python3.11",
+    "datadog_lambda:vXX",
+    "dd_lambda_layer:datadog-python311_X.X.X"
+  ]
+}
+HTTP GET https://datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "User-Agent:python-requests/X.X.X", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "XXXX.execute-api.eu-west-1.amazonaws.com",
+        "resource": "$default",
+        "name": "aws.apigateway.websocket",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "operation_name": "aws.apigateway.websocket",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com$default",
+          "endpoint": "$default",
+          "resource_names": "$default",
+          "apiid": "XXXX",
+          "apiname": "XXXX",
+          "stage": "dev",
+          "request_id": "XXXX",
+          "connection_id": "XXXX=",
+          "event_type": "MESSAGE",
+          "message_direction": "IN",
+          "_inferred_span.synchronicity": "sync",
+          "_inferred_span.tag_source": "self",
+          "http.status_code": "200",
+          "peer.service": "integration-tests-python",
+          "_dd.p.dm": "-0",
+          "language": "python",
+          "_dd.peer.service.source": "peer.service"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "web"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "aws.lambda",
+        "resource": "integration-tests-python-XXXX-sync-metrics_python311",
+        "name": "aws.lambda",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "cold_start": "false",
+          "function_arn": "arn:aws:lambda:eu-west-1:XXXX:eu-west-1-tests-python-XXXX-sync-metrics_python311",
+          "function_version": "$LATEST",
+          "request_id": "XXXX",
+          "resource_names": "integration-tests-python-XXXX-sync-metrics_python311",
+          "functionname": "integration-tests-python-XXXX-sync-metrics_python311",
+          "datadog_lambda": "X.X.X",
+          "dd_trace": "X.X.X",
+          "span.name": "aws.lambda",
+          "function_trigger.event_source": "api-gateway",
+          "function_trigger.event_source_arn": "XXXX",
+          "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
+          "http.status_code": "200"
+        },
+        "metrics": {
+          "_dd.top_level": 1
+        },
+        "type": "serverless"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://datadoghq.com/",
+          "out.host": "datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1,
+          "_dd.top_level": 1
+        },
+        "type": "http"
+      },
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "GET",
+          "http.url": "https://www.datadoghq.com/",
+          "out.host": "www.datadoghq.com",
+          "http.status_code": "200",
+          "http.useragent": "python-requests/X.X.X"
+        },
+        "metrics": {
+          "_dd.measured": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept-Encoding:gzip, deflate", "Accept:*/*", "Connection:keep-alive", "Content-Encoding:deflate", "Content-Length:XXXX", "Content-Type:application/json", "DD-API-KEY:XXXX", "User-Agent:datadogpy/XX (python XX; os linux; arch x86_64)", "traceparent:XXX", "tracestate:dd=s:1;t.dm:-0", "x-datadog-parent-id:XXXX", "x-datadog-sampling-priority:1", "x-datadog-tags:_dd.p.dm=-0", "x-datadog-trace-id:XXXX"] Data: {"series": [{"metric": "hello.dog", "points": [[XXXX, [1.0]]], "type": "distribution", "host": null, "device": null, "tags": ["team:serverless", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}, {"metric": "tests.integration.count", "points": [[XXXX, [21.0]]], "type": "distribution", "host": null, "device": null, "tags": ["test:integration", "role:hello", "dd_lambda_layer:datadog-python311_X.X.X", "service:integration-tests-python"], "interval": 10}]}
+{
+  "traces": [
+    [
+      {
+        "trace_id": "XXXX",
+        "parent_id": "XXXX",
+        "span_id": "XXXX",
+        "service": "integration-tests-python",
+        "resource": "requests.request",
+        "name": "requests.request",
+        "error": 0,
+        "start": "XXXX",
+        "duration": "XXXX",
+        "meta": {
+          "runtime-id": "XXXX",
+          "_dd.origin": "lambda",
+          "component": "requests",
+          "span.kind": "client",
+          "http.method": "POST",
+          "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
+          "out.host": "api.datadoghq.com",
+          "http.status_code": "202",
+          "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
+          "_dd.p.dm": "-0",
+          "language": "python"
+        },
+        "metrics": {
+          "process_id": XXXX,
+          "_dd.agent_psr": 1,
+          "_dd.measured": 1,
+          "_dd.top_level": 1,
+          "_sampling_priority_v1": 1
+        },
+        "type": "http"
+      }
+    ]
+  ]
+}
+END Duration: XXXX ms Memory Used: XXXX MB

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -48,8 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -108,7 +107,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -134,7 +132,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -167,7 +164,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -234,8 +230,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -290,7 +285,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -316,7 +310,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -349,7 +342,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -410,8 +402,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -465,7 +456,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -491,7 +481,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -524,7 +513,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -595,8 +583,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -655,7 +642,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -681,7 +667,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -714,7 +699,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -781,8 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -837,7 +820,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -863,7 +845,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -896,7 +877,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -960,8 +940,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1016,7 +995,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1042,7 +1020,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1075,7 +1052,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -1140,8 +1116,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1196,7 +1171,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1222,7 +1196,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1255,7 +1228,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -1319,8 +1291,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1375,7 +1346,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1401,7 +1371,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1434,7 +1403,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",
@@ -1504,8 +1472,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.p.dm": "-0",
-          "language": "python",
-          "_dd.peer.service.source": "peer.service"
+          "language": "python"
         },
         "metrics": {
           "process_id": XXXX,
@@ -1562,7 +1529,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://datadoghq.com/",
-          "out.host": "datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1588,7 +1554,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate", "
           "span.kind": "client",
           "http.method": "GET",
           "http.url": "https://www.datadoghq.com/",
-          "out.host": "www.datadoghq.com",
           "http.status_code": "200",
           "http.useragent": "python-requests/X.X.X"
         },
@@ -1621,7 +1586,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "span.kind": "client",
           "http.method": "POST",
           "http.url": "https://api.datadoghq.com/api/v1/distribution_points",
-          "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch x86_64)",
           "_dd.p.dm": "-0",

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -589,7 +589,7 @@ class TestSetTraceRootSpan(unittest.TestCase):
         self.mock_is_lambda_context = patcher.start()
         self.mock_is_lambda_context.return_value = True
         self.addCleanup(patcher.stop)
-        patcher = patch("ddtrace.tracer.context_provider.activate")
+        patcher = patch("datadog_lambda.tracing.tracer.context_provider.activate")
         self.mock_activate = patcher.start()
         self.mock_activate.return_value = True
         self.addCleanup(patcher.stop)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for Python 3.11

### Motivation

AWS [just released](https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/) Python 3.11 support.

### Testing Guidelines

Updated integration tests

### Additional Notes

N/A

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
