### PR TITLE
feat: EventBridge to SQS support

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -236,7 +236,8 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
 
     # EventBrdige => SQS
     try:
-        return _extract_context_from_eventbridge_sqs_event(event)
+        trace_id, parent_id, sampling_priority = _extract_context_from_eventbridge_sqs_event(event)
+        return trace_id, parent_id, sampling_priority
     except Exception:
         logger.debug("Failed extracting context as EventBridge to SQS.")
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -233,6 +233,13 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
 
     Falls back to lambda context if no trace data is found in the SQS message attributes.
     """
+
+    # EventBrdige => SQS
+    try:
+        return _extract_context_from_eventbridge_sqs_event(event)
+    except Exception:
+        logger.debug("Failed extracting context as EventBridge to SQS.")
+
     try:
         first_record = event.get("Records")[0]
 
@@ -281,6 +288,30 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
         return extract_context_from_lambda_context(lambda_context)
+
+
+def _extract_context_from_eventbridge_sqs_event(event):
+    """
+    Extracts Datadog trace context from an SQS event triggered by
+    EventBridge.
+
+    This is only possible if first record in `Records` contains a
+    `body` field which contains the EventBridge `detail` as a JSON string.
+    """
+    try:
+        first_record = event.get("Records")[0]
+        if "body" in first_record:
+            body_str = first_record.get("body", {})
+            body = json.loads(body_str)
+
+            detail = body.get("detail")
+            dd_context = detail.get("_datadog")
+            trace_id = dd_context.get(TraceHeader.TRACE_ID)
+            parent_id = dd_context.get(TraceHeader.PARENT_ID)
+            sampling_priority = dd_context.get(TraceHeader.SAMPLING_PRIORITY)
+            return trace_id, parent_id, sampling_priority
+    except Exception as e:
+        raise
 
 
 def extract_context_from_eventbridge_event(event, lambda_context):
@@ -995,21 +1026,33 @@ def create_inferred_span_from_sqs_event(event, context):
     }
     start_time = int(request_time_epoch) / 1000
 
-    # logic to deal with SNS => SQS event
-    sns_span = None
+    upstream_span = None
     if "body" in event_record:
         body_str = event_record.get("body", {})
         try:
             body = json.loads(body_str)
+
+            # logic to deal with SNS => SQS event
             if body.get("Type", "") == "Notification" and "TopicArn" in body:
                 logger.debug("Found SNS message inside SQS event")
-                sns_span = create_inferred_span_from_sns_event(
+                upstream_span = create_inferred_span_from_sns_event(
                     create_sns_event(body), context
                 )
-                sns_span.finish(finish_time=start_time)
+                upstream_span.finish(finish_time=start_time)
+
+            # EventBridge => SQS
+            elif body.get("detail"):
+                detail = body.get("detail")
+                if detail.get("_datadog"):
+                    logger.debug("Found an EventBridge message inside SQS event")
+                    upstream_span = create_inferred_span_from_eventbridge_event(
+                        body, context
+                    )
+                    upstream_span.finish(finish_time=start_time)
+            
         except Exception as e:
             logger.debug(
-                "Unable to create SNS span from SQS message, with error %s" % e
+                "Unable to create upstream span from SQS message, with error %s" % e
             )
             pass
 
@@ -1021,8 +1064,8 @@ def create_inferred_span_from_sqs_event(event, context):
     if span:
         span.set_tags(tags)
     span.start = start_time
-    if sns_span:
-        span.parent_id = sns_span.span_id
+    if upstream_span:
+        span.parent_id = upstream_span.span_id
 
     return span
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -236,7 +236,11 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
 
     # EventBrdige => SQS
     try:
-        trace_id, parent_id, sampling_priority = _extract_context_from_eventbridge_sqs_event(event)
+        (
+            trace_id,
+            parent_id,
+            sampling_priority,
+        ) = _extract_context_from_eventbridge_sqs_event(event)
         return trace_id, parent_id, sampling_priority
     except Exception:
         logger.debug("Failed extracting context as EventBridge to SQS.")

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -310,7 +310,7 @@ def _extract_context_from_eventbridge_sqs_event(event):
             parent_id = dd_context.get(TraceHeader.PARENT_ID)
             sampling_priority = dd_context.get(TraceHeader.SAMPLING_PRIORITY)
             return trace_id, parent_id, sampling_priority
-    except Exception as e:
+    except Exception:
         raise
 
 
@@ -1049,7 +1049,7 @@ def create_inferred_span_from_sqs_event(event, context):
                         body, context
                     )
                     upstream_span.finish(finish_time=start_time)
-            
+
         except Exception as e:
             logger.debug(
                 "Unable to create upstream span from SQS message, with error %s" % e

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -229,12 +229,19 @@ def create_sns_event(message):
 
 def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
     """
-    Extract Datadog trace context from the first SQS message attributes.
+    Extract Datadog trace context from an SQS event.
+
+    The extraction chain goes as follows:
+    EB => SQS (First records body contains EB context), or
+    SNS => SQS (First records body contains SNS context), or
+    SQS or SNS (`messageAttributes` for SQS context,
+                `MessageAttributes` for SNS context), else
+    Lambda Context.
 
     Falls back to lambda context if no trace data is found in the SQS message attributes.
     """
 
-    # EventBrdige => SQS
+    # EventBridge => SQS
     try:
         (
             trace_id,

--- a/tests/event_samples/eventbridge-sqs.json
+++ b/tests/event_samples/eventbridge-sqs.json
@@ -3,27 +3,7 @@
     {
       "messageId": "e995e54f-1724-41fa-82c0-8b81821f854e",
       "receiptHandle": "AQEB4mIfRcyqtzn1X5Ss+ConhTejVGc+qnAcmu3/Z9ZvbNkaPcpuDLX/bzvPD/ZkAXJUXZcemGSJmd7L3snZHKMP2Ck8runZiyl4mubiLb444pZvdiNPuGRJ6a3FvgS/GQPzho/9nNMyOi66m8Viwh70v4EUCPGO4JmD3TTDAUrrcAnqU4WSObjfC/NAp9bI6wH2CEyAYEfex6Nxplbl/jBf9ZUG0I3m3vQd0Q4l4gd4jIR4oxQUglU2Tldl4Kx5fMUAhTRLAENri6HsY81avBkKd9FAuxONlsITB5uj02kOkvLlRGEcalqsKyPJ7AFaDLrOLaL3U+yReroPEJ5R5nwhLOEbeN5HROlZRXeaAwZOIN8BjqdeooYTIOrtvMEVb7a6OPLMdH1XB+ddevtKAH8K9Tm2ZjpaA7dtBGh1zFVHzBk=",
-      "body": {
-        "version": "0",
-        "id": "af718b2a-b987-e8c0-7a2b-a188fad2661a",
-        "detail-type": "my.Detail",
-        "source": "my.Source",
-        "account": "425362996713",
-        "time": "2023-08-03T22: 49: 03Z",
-        "region": "us-east-1",
-        "resources": [],
-        "detail": {
-          "text": "Hello, world!",
-          "_datadog": {
-            "x-datadog-trace-id": "7379586022458917877",
-            "x-datadog-parent-id": "2644033662113726488",
-            "x-datadog-sampling-priority": "1",
-            "x-datadog-tags": "_dd.p.dm=-0",
-            "traceparent": "00-000000000000000066698e63821a03f5-24b17e9b6476c018-01",
-            "tracestate": "dd=t.dm: -0;s: 1"
-          }
-        }
-      },
+      "body": "{\"version\":\"0\",\"id\":\"af718b2a-b987-e8c0-7a2b-a188fad2661a\",\"detail-type\":\"my.Detail\",\"source\":\"my.Source\",\"account\":\"425362996713\",\"time\":\"2023-08-03T22:49:03Z\",\"region\":\"us-east-1\",\"resources\":[],\"detail\":{\"text\":\"Hello, world!\",\"_datadog\":{\"x-datadog-trace-id\":\"7379586022458917877\",\"x-datadog-parent-id\":\"2644033662113726488\",\"x-datadog-sampling-priority\":\"1\",\"x-datadog-tags\":\"_dd.p.dm=-0\",\"traceparent\":\"00-000000000000000066698e63821a03f5-24b17e9b6476c018-01\",\"tracestate\":\"dd=t.dm:-0;s:1\"}}}",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "AWSTraceHeader": "Root=1-64cc2edd-112fbf1701d1355973a11d57;Parent=7d5a9776024b2d42;Sampled=0",

--- a/tests/event_samples/eventbridge-sqs.json
+++ b/tests/event_samples/eventbridge-sqs.json
@@ -1,0 +1,41 @@
+{
+  "Records": [
+    {
+      "messageId": "e995e54f-1724-41fa-82c0-8b81821f854e",
+      "receiptHandle": "AQEB4mIfRcyqtzn1X5Ss+ConhTejVGc+qnAcmu3/Z9ZvbNkaPcpuDLX/bzvPD/ZkAXJUXZcemGSJmd7L3snZHKMP2Ck8runZiyl4mubiLb444pZvdiNPuGRJ6a3FvgS/GQPzho/9nNMyOi66m8Viwh70v4EUCPGO4JmD3TTDAUrrcAnqU4WSObjfC/NAp9bI6wH2CEyAYEfex6Nxplbl/jBf9ZUG0I3m3vQd0Q4l4gd4jIR4oxQUglU2Tldl4Kx5fMUAhTRLAENri6HsY81avBkKd9FAuxONlsITB5uj02kOkvLlRGEcalqsKyPJ7AFaDLrOLaL3U+yReroPEJ5R5nwhLOEbeN5HROlZRXeaAwZOIN8BjqdeooYTIOrtvMEVb7a6OPLMdH1XB+ddevtKAH8K9Tm2ZjpaA7dtBGh1zFVHzBk=",
+      "body": {
+        "version": "0",
+        "id": "af718b2a-b987-e8c0-7a2b-a188fad2661a",
+        "detail-type": "my.Detail",
+        "source": "my.Source",
+        "account": "425362996713",
+        "time": "2023-08-03T22: 49: 03Z",
+        "region": "us-east-1",
+        "resources": [],
+        "detail": {
+          "text": "Hello, world!",
+          "_datadog": {
+            "x-datadog-trace-id": "7379586022458917877",
+            "x-datadog-parent-id": "2644033662113726488",
+            "x-datadog-sampling-priority": "1",
+            "x-datadog-tags": "_dd.p.dm=-0",
+            "traceparent": "00-000000000000000066698e63821a03f5-24b17e9b6476c018-01",
+            "tracestate": "dd=t.dm: -0;s: 1"
+          }
+        }
+      },
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "AWSTraceHeader": "Root=1-64cc2edd-112fbf1701d1355973a11d57;Parent=7d5a9776024b2d42;Sampled=0",
+        "SentTimestamp": "1691102943638",
+        "SenderId": "AIDAJXNJGGKNS7OSV23OI",
+        "ApproximateFirstReceiveTimestamp": "1691102943647"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "93d9f0cd8886d1e000a1a0b7007bffc4",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:425362996713:eventbridge-sqs-queue",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1823,7 +1823,6 @@ class TestInferredSpans(unittest.TestCase):
         self.assertEqual(span.get_tag(InferredSpanInfo.TAG_SOURCE), "self")
         self.assertEqual(span.get_tag(InferredSpanInfo.SYNCHRONICITY), "async")
 
-
     def test_extract_context_from_eventbridge_event(self):
         event_sample_source = "eventbridge-custom"
         test_file = event_samples + event_sample_source + ".json"
@@ -1845,7 +1844,6 @@ class TestInferredSpans(unittest.TestCase):
         self.assertEqual(context["trace-id"], "12345")
         self.assertEqual(context["parent-id"], "67890")
 
-
     def test_extract_context_from_eventbridge_sqs_event(self):
         event_sample_source = "eventbridge-sqs"
         test_file = event_samples + event_sample_source + ".json"
@@ -1857,7 +1855,6 @@ class TestInferredSpans(unittest.TestCase):
         self.assertEqual(context["trace-id"], "7379586022458917877")
         self.assertEqual(context["parent-id"], "2644033662113726488")
         self.assertEqual(context["sampling-priority"], "1")
-
 
     def test_extract_context_from_sqs_event_with_string_msg_attr(self):
         event_sample_source = "sqs-string-msg-attribute"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1853,7 +1853,7 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
 
         ctx = get_mock_context()
-        context, _, __ = extract_dd_trace_context(event, ctx)
+        context, source, event_type = extract_dd_trace_context(event, ctx)
         self.assertEqual(context["trace-id"], "7379586022458917877")
         self.assertEqual(context["parent-id"], "2644033662113726488")
         self.assertEqual(context["sampling-priority"], "1")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for tracing <EventBridge to SQS> payloads.

### Motivation

It's possible to have distributed tracing on it, so why not?

### Testing Guidelines

Added unit tests.
Also tested manually.

<img width="1250" alt="Screenshot 2023-08-04 at 8 20 53 PM" src="https://github.com/DataDog/datadog-lambda-python/assets/30836115/9e3d83ec-42f6-4248-b1d4-e8dde0241a43">

### Additional Notes

Since EventBridge doesn't provide resolution in milliseconds, we end up with really large spans for it.
Maybe this can be fixed by adding a new field. Research is still needed for this.

<img width="1256" alt="Screenshot 2023-08-04 at 8 21 17 PM" src="https://github.com/DataDog/datadog-lambda-python/assets/30836115/b20847c0-6dae-455f-9e91-448472d8098c">

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
