### PR TITLE
feat: Support DD_TRACE_OTEL_ENABLED env var

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -29,7 +29,9 @@ from datadog_lambda.xray import (
     send_segment,
     parse_xray_header,
 )
-dd_trace_otel_enabled = os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
+dd_trace_otel_enabled = (
+    os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
+)
 if dd_trace_otel_enabled:
     from opentelemetry.trace import set_tracer_provider
     from ddtrace.opentelemetry import TracerProvider

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -29,6 +29,12 @@ from datadog_lambda.xray import (
     send_segment,
     parse_xray_header,
 )
+dd_trace_otel_enabled = os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
+if dd_trace_otel_enabled:
+    from opentelemetry.trace import set_tracer_provider
+    from ddtrace.opentelemetry import TracerProvider
+
+    set_tracer_provider(TracerProvider())
 from ddtrace import tracer, patch, Span
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -30,14 +30,6 @@ from datadog_lambda.xray import (
     parse_xray_header,
 )
 
-dd_trace_otel_enabled = (
-    os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
-)
-if dd_trace_otel_enabled:
-    from opentelemetry.trace import set_tracer_provider
-    from ddtrace.opentelemetry import TracerProvider
-
-    set_tracer_provider(TracerProvider())
 from ddtrace import tracer, patch, Span
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator
@@ -49,6 +41,16 @@ from datadog_lambda.trigger import (
     EventTypes,
     EventSubtypes,
 )
+
+dd_trace_otel_enabled = (
+    os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
+)
+if dd_trace_otel_enabled:
+    from opentelemetry.trace import set_tracer_provider
+    from ddtrace.opentelemetry import TracerProvider
+
+    set_tracer_provider(TracerProvider())
+
 
 logger = logging.getLogger(__name__)
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -29,6 +29,7 @@ from datadog_lambda.xray import (
     send_segment,
     parse_xray_header,
 )
+
 dd_trace_otel_enabled = (
     os.environ.get("DD_TRACE_OTEL_ENABLED", "false").lower() == "true"
 )

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -29,7 +29,6 @@ from datadog_lambda.xray import (
     send_segment,
     parse_xray_header,
 )
-
 from ddtrace import tracer, patch, Span
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Honors the DD_TRACE_OTEL_ENABLED env var so users can utilize the otel SDK in Lambda. Allows users to mix and match:
<img width="1150" alt="image" src="https://github.com/DataDog/datadog-lambda-python/assets/1598537/01db72dd-c412-4c08-8189-1fa315357604">


### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
