### PR TITLE
change the traceback format to print in one line

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -126,7 +126,9 @@ class _LambdaDecorator(object):
                 logger.debug("datadog_lambda_wrapper already wrapped")
                 return _NoopDecorator(func)
         except Exception as e:
-            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
+            logger.error(
+                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
+            )
             return func
 
     def __init__(self, func):
@@ -205,7 +207,9 @@ class _LambdaDecorator(object):
 
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:
-            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
+            logger.error(
+                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
+            )
 
     def __call__(self, event, context, **kwargs):
         """Executes when the wrapped function gets called"""
@@ -292,7 +296,9 @@ class _LambdaDecorator(object):
                 self.prof.start(stop_on_exit=False, profile_children=True)
             logger.debug("datadog_lambda_wrapper _before() done")
         except Exception as e:
-            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
+            logger.error(
+                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
+            )
 
     def _after(self, event, context):
         try:
@@ -359,7 +365,9 @@ class _LambdaDecorator(object):
                 )
             logger.debug("datadog_lambda_wrapper _after() done")
         except Exception as e:
-            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
+            logger.error(
+                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
+            )
 
 
 datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -125,9 +125,8 @@ class _LambdaDecorator(object):
             else:
                 logger.debug("datadog_lambda_wrapper already wrapped")
                 return _NoopDecorator(func)
-        except Exception:
-            traceback.print_exc()
-            return func
+        except Exception as e:
+            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
 
     def __init__(self, func):
         """Executes when the wrapped function gets wrapped"""
@@ -204,8 +203,8 @@ class _LambdaDecorator(object):
             patch_all()
 
             logger.debug("datadog_lambda_wrapper initialized")
-        except Exception:
-            traceback.print_exc()
+        except Exception as e:
+            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
 
     def __call__(self, event, context, **kwargs):
         """Executes when the wrapped function gets called"""
@@ -291,8 +290,8 @@ class _LambdaDecorator(object):
             if profiling_env_var and is_new_sandbox():
                 self.prof.start(stop_on_exit=False, profile_children=True)
             logger.debug("datadog_lambda_wrapper _before() done")
-        except Exception:
-            traceback.print_exc()
+        except Exception as e:
+            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
 
     def _after(self, event, context):
         try:
@@ -358,8 +357,8 @@ class _LambdaDecorator(object):
                     event.get("requestContext", {}).get("requestId")
                 )
             logger.debug("datadog_lambda_wrapper _after() done")
-        except Exception:
-            traceback.print_exc()
+        except Exception as e:
+            logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
 
 
 datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -127,6 +127,7 @@ class _LambdaDecorator(object):
                 return _NoopDecorator(func)
         except Exception as e:
             logger.error("Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r"))
+            return func
 
     def __init__(self, func):
         """Executes when the wrapped function gets wrapped"""

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -126,9 +126,7 @@ class _LambdaDecorator(object):
                 logger.debug("datadog_lambda_wrapper already wrapped")
                 return _NoopDecorator(func)
         except Exception as e:
-            logger.error(
-                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
-            )
+            logger.error(format_err_with_traceback(e))
             return func
 
     def __init__(self, func):
@@ -207,9 +205,7 @@ class _LambdaDecorator(object):
 
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:
-            logger.error(
-                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
-            )
+            logger.error(format_err_with_traceback(e))
 
     def __call__(self, event, context, **kwargs):
         """Executes when the wrapped function gets called"""
@@ -296,9 +292,7 @@ class _LambdaDecorator(object):
                 self.prof.start(stop_on_exit=False, profile_children=True)
             logger.debug("datadog_lambda_wrapper _before() done")
         except Exception as e:
-            logger.error(
-                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
-            )
+            logger.error(format_err_with_traceback(e))
 
     def _after(self, event, context):
         try:
@@ -365,9 +359,13 @@ class _LambdaDecorator(object):
                 )
             logger.debug("datadog_lambda_wrapper _after() done")
         except Exception as e:
-            logger.error(
-                "Error %s. Traceback: %s", e, traceback.format_exc().replace("\n", "\r")
-            )
+            logger.error(format_err_with_traceback(e))
+
+
+def format_err_with_traceback(e):
+    return "Error {}. Traceback: {}".format(
+        e, traceback.format_exc().replace("\n", "\r")
+    )
 
 
 datadog_lambda_wrapper = _LambdaDecorator


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Format the traceback printout to one line

### Motivation

Otherwise the printout would be split into multiple lines and would be hard to read and search.

### Testing Guidelines

This trick is just to replace `\n` with `\r` and the result looks like this:

Before:
<img width="1129" alt="Screenshot 2023-08-22 at 10 03 38 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/5253430/664075d9-9f4a-42fc-96d5-c2c8df22be01">


After:
<img width="1179" alt="Screenshot 2023-08-22 at 10 04 15 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/5253430/d80706e4-7da1-40d1-83e7-5ec57a563b03">

If we replace with `\n` with `\\n` instead:
<img width="1170" alt="Screenshot 2023-08-22 at 10 49 26 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/5253430/7e349979-4707-49b1-8547-8a2d0ac16f7a">



### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
