### PR TITLE
enhancing tag_object

### DIFF
--- a/datadog_lambda/tag_object.py
+++ b/datadog_lambda/tag_object.py
@@ -28,18 +28,27 @@ def tag_object(span, key, obj, depth=0):
             redacted = _redact_val(key, obj[0:5000])
             return span.set_tag(key, redacted)
     if isinstance(obj, int) or isinstance(obj, float) or isinstance(obj, Decimal):
-        return span.set_tag(key, obj)
+        return span.set_tag(key, str(obj))
     if isinstance(obj, list):
         for k, v in enumerate(obj):
             formatted_key = "{}.{}".format(key, k)
             tag_object(span, formatted_key, v, depth)
         return
-    if isinstance(obj, object):
-        for k in obj:
-            v = obj.get(k)
+    if hasattr(obj, 'items'):
+        for k, v in obj.items():
             formatted_key = "{}.{}".format(key, k)
             tag_object(span, formatted_key, v, depth)
         return
+    if hasattr(obj, 'to_dict'):
+        for k, v in obj.to_dict().items():
+            formatted_key = "{}.{}".format(key, k)
+            tag_object(span, formatted_key, v, depth)
+        return
+    try:
+        value_as_str= str(obj)
+    except Exception:
+        value_as_str="UNKNOWN"
+    return span.set_tag(key, value_as_str)
 
 
 def _should_try_string(obj):

--- a/datadog_lambda/tag_object.py
+++ b/datadog_lambda/tag_object.py
@@ -34,20 +34,20 @@ def tag_object(span, key, obj, depth=0):
             formatted_key = "{}.{}".format(key, k)
             tag_object(span, formatted_key, v, depth)
         return
-    if hasattr(obj, 'items'):
+    if hasattr(obj, "items"):
         for k, v in obj.items():
             formatted_key = "{}.{}".format(key, k)
             tag_object(span, formatted_key, v, depth)
         return
-    if hasattr(obj, 'to_dict'):
+    if hasattr(obj, "to_dict"):
         for k, v in obj.to_dict().items():
             formatted_key = "{}.{}".format(key, k)
             tag_object(span, formatted_key, v, depth)
         return
     try:
-        value_as_str= str(obj)
+        value_as_str = str(obj)
     except Exception:
-        value_as_str="UNKNOWN"
+        value_as_str = "UNKNOWN"
     return span.set_tag(key, value_as_str)
 
 

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -19,12 +19,12 @@ class TestTagObject(unittest.TestCase):
         tag_object(spanMock, "function.request", payload)
         spanMock.set_tag.assert_has_calls(
             [
-                call("function.request.vals.0.thingOne", 1),
-                call("function.request.vals.1.thingTwo", 2),
+                call("function.request.vals.0.thingOne", "1"),
+                call("function.request.vals.1.thingTwo", "2"),
                 call("function.request.hello", "world"),
                 call("function.request.anotherThing.blah", None),
                 call("function.request.anotherThing.foo", "bar"),
-                call("function.request.anotherThing.nice", True),
+                call("function.request.anotherThing.nice", "True"),
             ],
             True,
         )
@@ -85,12 +85,57 @@ class TestTagObject(unittest.TestCase):
         )
 
     def test_decimal_tag_object(self):
-        payload = {"myValue": Decimal(500.50)}
+        payload = {"myValue": Decimal(500.5)}
         spanMock = MagicMock()
         tag_object(spanMock, "function.request", payload)
         spanMock.set_tag.assert_has_calls(
             [
-                call("function.request.myValue", Decimal(500.50)),
+                call("function.request.myValue", "500.5"),
+            ],
+            True,
+        )
+
+
+    class CustomResponse(object):
+        """
+        For example, chalice.app.Response class
+        """
+        def __init__(
+            self, body,
+            headers = None,
+            status_code: int = 200
+        ):
+            self.body = body
+            if headers is None:
+                headers = {}
+            self.headers = headers
+            self.status_code = status_code
+
+        def __str__(self):
+            return str(self.body)
+
+    class ResponseHasToDict(CustomResponse):
+        def to_dict(self):
+            return self.headers
+
+    def test_custom_response(self):
+        payload = self.CustomResponse({'hello':'world'}, {'key1':'val1'}, 200)
+        spanMock = MagicMock()
+        tag_object(spanMock, "function.response", payload)
+        spanMock.set_tag.assert_has_calls(
+            [
+                call("function.response", "{'hello': 'world'}"),
+            ],
+            True,
+        )
+
+    def test_custom_response_to_dict(self):
+        payload = self.ResponseHasToDict({'hello':'world'}, {'key1':'val1'}, 200)
+        spanMock = MagicMock()
+        tag_object(spanMock, "function.response", payload)
+        spanMock.set_tag.assert_has_calls(
+            [
+                call("function.response.key1", "val1"),
             ],
             True,
         )

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -40,12 +40,12 @@ class TestTagObject(unittest.TestCase):
         tag_object(spanMock, "function.request", payload)
         spanMock.set_tag.assert_has_calls(
             [
-                call("function.request.vals.0.thingOne", 1),
-                call("function.request.vals.1.thingTwo", 2),
+                call("function.request.vals.0.thingOne", "1"),
+                call("function.request.vals.1.thingTwo", "2"),
                 call("function.request.authorization", "redacted"),
                 call("function.request.anotherThing.blah", None),
                 call("function.request.anotherThing.password", "redacted"),
-                call("function.request.anotherThing.nice", True),
+                call("function.request.anotherThing.nice", "True"),
             ],
             True,
         )
@@ -62,7 +62,7 @@ class TestTagObject(unittest.TestCase):
                 call("function.request.token", "redacted"),
                 call("function.request.jsonString.stringifyThisJson.0.here", "is"),
                 call("function.request.jsonString.stringifyThisJson.0.an", "object"),
-                call("function.request.jsonString.stringifyThisJson.0.number", 1),
+                call("function.request.jsonString.stringifyThisJson.0.number", "1"),
             ],
             True,
         )
@@ -79,7 +79,7 @@ class TestTagObject(unittest.TestCase):
                 call("function.request.token", "redacted"),
                 call("function.request.jsonString.stringifyThisJson.0.here", "is"),
                 call("function.request.jsonString.stringifyThisJson.0.an", "object"),
-                call("function.request.jsonString.stringifyThisJson.0.number", 1),
+                call("function.request.jsonString.stringifyThisJson.0.number", "1"),
             ],
             True,
         )
@@ -95,16 +95,12 @@ class TestTagObject(unittest.TestCase):
             True,
         )
 
-
     class CustomResponse(object):
         """
         For example, chalice.app.Response class
         """
-        def __init__(
-            self, body,
-            headers = None,
-            status_code: int = 200
-        ):
+
+        def __init__(self, body, headers=None, status_code: int = 200):
             self.body = body
             if headers is None:
                 headers = {}
@@ -119,7 +115,7 @@ class TestTagObject(unittest.TestCase):
             return self.headers
 
     def test_custom_response(self):
-        payload = self.CustomResponse({'hello':'world'}, {'key1':'val1'}, 200)
+        payload = self.CustomResponse({"hello": "world"}, {"key1": "val1"}, 200)
         spanMock = MagicMock()
         tag_object(spanMock, "function.response", payload)
         spanMock.set_tag.assert_has_calls(
@@ -130,7 +126,7 @@ class TestTagObject(unittest.TestCase):
         )
 
     def test_custom_response_to_dict(self):
-        payload = self.ResponseHasToDict({'hello':'world'}, {'key1':'val1'}, 200)
+        payload = self.ResponseHasToDict({"hello": "world"}, {"key1": "val1"}, 200)
         spanMock = MagicMock()
         tag_object(spanMock, "function.response", payload)
         spanMock.set_tag.assert_has_calls(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

1. Same as https://github.com/DataDog/datadog-lambda-js/pull/422. 
2. Enhanced the tag_object method further so that it can support `chalice.app.response` and other types so that the trace doesn't break when the `DD_CAPTURE_LAMBDA_PAYLOAD` enabled.

### Motivation
1. Same as https://github.com/DataDog/datadog-lambda-js/pull/422. 
2. https://datadoghq.atlassian.net/browse/SVLS-3522

### Testing Guidelines

1. This has been tested in us-west-2 in  serverless sandbox account with `joey-python-hello-world` function
2. This has been tested in us-west-1 in serverless sandbox account with `helloworld-dev` function
<img width="225" alt="image" src="https://github.com/DataDog/datadog-lambda-python/assets/5253430/40a93caf-9c58-4fab-b66a-3e25ea386c9f">


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
