### PR TITLE
add a step to extract the dependencies info when building the layers

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -60,6 +60,9 @@ function docker_build_zip {
     (cd $temp_dir && zip -q -r $destination ./)
 
     rm -rf $temp_dir
+    docker run datadog-lambda-python-${arch}:$1 sh -c "cd /build/python/lib/python$1/site-packages/ && \
+        python -c \"import pkg_resources; packages = sorted(['%s==%s' % (i.key, i.version) for i in pkg_resources.working_set]);\
+        print(*packages,sep ='\n')\"" > dependency.lock.${arch}.$1
     echo "Done creating archive $destination"
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This added command will export a `dependency.lock.${architecture}.${pythonversion}` file per architecture per python version. For example, `dependency.lock.amd64.3.11`.
### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
