### PR TITLE
feat: opt-in enablement of the instrumentation telemetry client

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -55,6 +55,11 @@ logger = logging.getLogger(__name__)
 
 dd_trace_context = {}
 dd_tracing_enabled = os.environ.get("DD_TRACE_ENABLED", "false").lower() == "true"
+if dd_tracing_enabled:
+    # Enable the telemetry client if the user has opted in
+    if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false").lower() == "true":
+        from ddtrace.internal.telemetry import telemetry_writer
+        telemetry_writer.enable()
 
 propagator = HTTPPropagator()
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -62,6 +62,7 @@ if dd_tracing_enabled:
         == "true"
     ):
         from ddtrace.internal.telemetry import telemetry_writer
+
         telemetry_writer.enable()
 
 propagator = HTTPPropagator()

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -57,7 +57,10 @@ dd_trace_context = {}
 dd_tracing_enabled = os.environ.get("DD_TRACE_ENABLED", "false").lower() == "true"
 if dd_tracing_enabled:
     # Enable the telemetry client if the user has opted in
-    if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false").lower() == "true":
+    if (
+        os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false").lower()
+        == "true"
+    ):
         from ddtrace.internal.telemetry import telemetry_writer
         telemetry_writer.enable()
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Enable the telemetry client when `DD_INSTRUMENTATION_TELEMETRY_ENABLED=true`

<!--- A brief description of the change being made with this pull request. --->

### Motivation

AppSec Open-Source Software Vulnerability Scanning (aka ASM OSS Vulns) works on top of telemetry data sent by the tracing libraries. We are launching our beta for AWS Lambda using this short-term solution, but the mid-term one is to leverage a side-scanning agent instead, not requiring instrumentation telemetry at all, and out of the lambdas and tracers. 

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->
Jira: APPSEC-11434

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
