### PR TITLE
Defer trace context extraction to ddtrace.

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -20,7 +20,6 @@ except ImportError:
 
 from datadog_lambda.constants import (
     SamplingPriority,
-    TraceHeader,
     TraceContextSource,
     XrayDaemon,
     Headers,
@@ -32,6 +31,7 @@ from datadog_lambda.xray import (
 from ddtrace import tracer, patch, Span
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator
+from ddtrace.context import Context
 from datadog_lambda import __version__ as datadog_lambda_version
 from datadog_lambda.trigger import (
     _EventSource,
@@ -53,7 +53,7 @@ if dd_trace_otel_enabled:
 
 logger = logging.getLogger(__name__)
 
-dd_trace_context = {}
+dd_trace_context = None
 dd_tracing_enabled = os.environ.get("DD_TRACE_ENABLED", "false").lower() == "true"
 if dd_tracing_enabled:
     # Enable the telemetry client if the user has opted in
@@ -102,11 +102,11 @@ def _get_xray_trace_context():
     )
     if xray_trace_entity is None:
         return None
-    trace_context = {
-        "trace-id": _convert_xray_trace_id(xray_trace_entity.get("trace_id")),
-        "parent-id": _convert_xray_entity_id(xray_trace_entity.get("parent_id")),
-        "sampling-priority": _convert_xray_sampling(xray_trace_entity.get("sampled")),
-    }
+    trace_context = Context(
+        trace_id=_convert_xray_trace_id(xray_trace_entity.get("trace_id")),
+        span_id=_convert_xray_entity_id(xray_trace_entity.get("parent_id")),
+        sampling_priority=_convert_xray_sampling(xray_trace_entity.get("sampled")),
+    )
     logger.debug(
         "Converted trace context %s from X-Ray segment %s",
         trace_context,
@@ -124,26 +124,19 @@ def _get_dd_trace_py_context():
     if not span:
         return None
 
-    parent_id = span.context.span_id
-    trace_id = span.context.trace_id
-    sampling_priority = span.context.sampling_priority
     logger.debug(
         "found dd trace context: %s", (span.context.trace_id, span.context.span_id)
     )
-    return {
-        "parent-id": str(parent_id),
-        "trace-id": str(trace_id),
-        "sampling-priority": str(sampling_priority),
-        "source": TraceContextSource.DDTRACE,
-    }
+    return span.context
 
 
-def _context_obj_to_headers(obj):
-    return {
-        TraceHeader.TRACE_ID: str(obj.get("trace-id")),
-        TraceHeader.PARENT_ID: str(obj.get("parent-id")),
-        TraceHeader.SAMPLING_PRIORITY: str(obj.get("sampling-priority")),
-    }
+def _is_context_complete(context):
+    return (
+        context
+        and context.trace_id
+        and context.span_id
+        and context.sampling_priority is not None
+    )
 
 
 def create_dd_dummy_metadata_subsegment(
@@ -164,28 +157,14 @@ def extract_context_from_lambda_context(lambda_context):
 
     dd_trace libraries inject this trace context on synchronous invocations
     """
+    dd_data = None
     client_context = lambda_context.client_context
-    trace_id = None
-    parent_id = None
-    sampling_priority = None
     if client_context and client_context.custom:
+        dd_data = client_context.custom
         if "_datadog" in client_context.custom:
             # Legacy trace propagation dict
-            dd_data = client_context.custom.get("_datadog", {})
-            trace_id = dd_data.get(TraceHeader.TRACE_ID)
-            parent_id = dd_data.get(TraceHeader.PARENT_ID)
-            sampling_priority = dd_data.get(TraceHeader.SAMPLING_PRIORITY)
-        elif (
-            TraceHeader.TRACE_ID in client_context.custom
-            and TraceHeader.PARENT_ID in client_context.custom
-            and TraceHeader.SAMPLING_PRIORITY in client_context.custom
-        ):
-            # New trace propagation keys
-            trace_id = client_context.custom.get(TraceHeader.TRACE_ID)
-            parent_id = client_context.custom.get(TraceHeader.PARENT_ID)
-            sampling_priority = client_context.custom.get(TraceHeader.SAMPLING_PRIORITY)
-
-    return trace_id, parent_id, sampling_priority
+            dd_data = client_context.custom.get("_datadog")
+    return propagator.extract(dd_data)
 
 
 def extract_context_from_http_event_or_context(
@@ -205,33 +184,17 @@ def extract_context_from_http_event_or_context(
             EventTypes.API_GATEWAY, subtype=EventSubtypes.HTTP_API
         )
         injected_authorizer_data = get_injected_authorizer_data(event, is_http_api)
-        if injected_authorizer_data:
-            try:
-                # fail fast on any KeyError here
-                trace_id = injected_authorizer_data[TraceHeader.TRACE_ID]
-                parent_id = injected_authorizer_data[TraceHeader.PARENT_ID]
-                sampling_priority = injected_authorizer_data.get(
-                    TraceHeader.SAMPLING_PRIORITY
-                )
-                return trace_id, parent_id, sampling_priority
-            except Exception as e:
-                logger.debug(
-                    "extract_context_from_authorizer_event returned with error. \
-                     Continue without injecting the authorizer span %s",
-                    e,
-                )
+        context = propagator.extract(injected_authorizer_data)
+        if _is_context_complete(context):
+            return context
 
-    headers = event.get("headers", {}) or {}
-    lowercase_headers = {k.lower(): v for k, v in headers.items()}
+    headers = event.get("headers")
+    context = propagator.extract(headers)
 
-    trace_id = lowercase_headers.get(TraceHeader.TRACE_ID)
-    parent_id = lowercase_headers.get(TraceHeader.PARENT_ID)
-    sampling_priority = lowercase_headers.get(TraceHeader.SAMPLING_PRIORITY)
-
-    if not trace_id or not parent_id or not sampling_priority:
+    if not _is_context_complete(context):
         return extract_context_from_lambda_context(lambda_context)
 
-    return trace_id, parent_id, sampling_priority
+    return context
 
 
 def create_sns_event(message):
@@ -262,12 +225,9 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
 
     # EventBridge => SQS
     try:
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = _extract_context_from_eventbridge_sqs_event(event)
-        return trace_id, parent_id, sampling_priority
+        context = _extract_context_from_eventbridge_sqs_event(event)
+        if _is_context_complete(context):
+            return context
     except Exception:
         logger.debug("Failed extracting context as EventBridge to SQS.")
 
@@ -311,11 +271,7 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
                 "context from String or Binary SQS/SNS message attributes"
             )
         dd_data = json.loads(dd_json_data)
-        trace_id = dd_data.get(TraceHeader.TRACE_ID)
-        parent_id = dd_data.get(TraceHeader.PARENT_ID)
-        sampling_priority = dd_data.get(TraceHeader.SAMPLING_PRIORITY)
-
-        return trace_id, parent_id, sampling_priority
+        return propagator.extract(dd_data)
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
         return extract_context_from_lambda_context(lambda_context)
@@ -329,20 +285,12 @@ def _extract_context_from_eventbridge_sqs_event(event):
     This is only possible if first record in `Records` contains a
     `body` field which contains the EventBridge `detail` as a JSON string.
     """
-    try:
-        first_record = event.get("Records")[0]
-        if "body" in first_record:
-            body_str = first_record.get("body", {})
-            body = json.loads(body_str)
-
-            detail = body.get("detail")
-            dd_context = detail.get("_datadog")
-            trace_id = dd_context.get(TraceHeader.TRACE_ID)
-            parent_id = dd_context.get(TraceHeader.PARENT_ID)
-            sampling_priority = dd_context.get(TraceHeader.SAMPLING_PRIORITY)
-            return trace_id, parent_id, sampling_priority
-    except Exception:
-        raise
+    first_record = event.get("Records")[0]
+    body_str = first_record.get("body")
+    body = json.loads(body_str)
+    detail = body.get("detail")
+    dd_context = detail.get("_datadog")
+    return propagator.extract(dd_context)
 
 
 def extract_context_from_eventbridge_event(event, lambda_context):
@@ -355,10 +303,7 @@ def extract_context_from_eventbridge_event(event, lambda_context):
         dd_context = detail.get("_datadog")
         if not dd_context:
             return extract_context_from_lambda_context(lambda_context)
-        trace_id = dd_context.get(TraceHeader.TRACE_ID)
-        parent_id = dd_context.get(TraceHeader.PARENT_ID)
-        sampling_priority = dd_context.get(TraceHeader.SAMPLING_PRIORITY)
-        return trace_id, parent_id, sampling_priority
+        return propagator.extract(dd_context)
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
         return extract_context_from_lambda_context(lambda_context)
@@ -381,10 +326,7 @@ def extract_context_from_kinesis_event(event, lambda_context):
         if not dd_ctx:
             return extract_context_from_lambda_context(lambda_context)
 
-        trace_id = dd_ctx.get(TraceHeader.TRACE_ID)
-        parent_id = dd_ctx.get(TraceHeader.PARENT_ID)
-        sampling_priority = dd_ctx.get(TraceHeader.SAMPLING_PRIORITY)
-        return trace_id, parent_id, sampling_priority
+        return propagator.extract(dd_ctx)
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
         return extract_context_from_lambda_context(lambda_context)
@@ -417,7 +359,9 @@ def extract_context_from_step_functions(event, lambda_context):
             execution_id + "#" + state_name + "#" + state_entered_time
         )
         sampling_priority = SamplingPriority.AUTO_KEEP
-        return trace_id, parent_id, sampling_priority
+        return Context(
+            trace_id=trace_id, span_id=parent_id, sampling_priority=sampling_priority
+        )
     except Exception as e:
         logger.debug("The Step Functions trace extractor returned with error %s", e)
         return extract_context_from_lambda_context(lambda_context)
@@ -433,11 +377,11 @@ def extract_context_custom_extractor(extractor, event, lambda_context):
             parent_id,
             sampling_priority,
         ) = extractor(event, lambda_context)
-        return trace_id, parent_id, sampling_priority
+        return Context(
+            trace_id=trace_id, span_id=parent_id, sampling_priority=sampling_priority
+        )
     except Exception as e:
         logger.debug("The trace extractor returned with error %s", e)
-
-        return None, None, None
 
 
 def is_authorizer_response(response) -> bool:
@@ -504,56 +448,27 @@ def extract_dd_trace_context(
     event_source = parse_event_source(event)
 
     if extractor is not None:
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_custom_extractor(extractor, event, lambda_context)
+        context = extract_context_custom_extractor(extractor, event, lambda_context)
     elif isinstance(event, (set, dict)) and "headers" in event:
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_from_http_event_or_context(
+        context = extract_context_from_http_event_or_context(
             event, lambda_context, event_source, decode_authorizer_context
         )
     elif event_source.equals(EventTypes.SNS) or event_source.equals(EventTypes.SQS):
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_from_sqs_or_sns_event_or_context(event, lambda_context)
-    elif event_source.equals(EventTypes.EVENTBRIDGE):
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_from_eventbridge_event(event, lambda_context)
-    elif event_source.equals(EventTypes.KINESIS):
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_from_kinesis_event(event, lambda_context)
-    elif event_source.equals(EventTypes.STEPFUNCTIONS):
-        (
-            trace_id,
-            parent_id,
-            sampling_priority,
-        ) = extract_context_from_step_functions(event, lambda_context)
-    else:
-        trace_id, parent_id, sampling_priority = extract_context_from_lambda_context(
-            lambda_context
+        context = extract_context_from_sqs_or_sns_event_or_context(
+            event, lambda_context
         )
+    elif event_source.equals(EventTypes.EVENTBRIDGE):
+        context = extract_context_from_eventbridge_event(event, lambda_context)
+    elif event_source.equals(EventTypes.KINESIS):
+        context = extract_context_from_kinesis_event(event, lambda_context)
+    elif event_source.equals(EventTypes.STEPFUNCTIONS):
+        context = extract_context_from_step_functions(event, lambda_context)
+    else:
+        context = extract_context_from_lambda_context(lambda_context)
 
-    if trace_id and parent_id and sampling_priority:
+    if _is_context_complete(context):
         logger.debug("Extracted Datadog trace context from event or context")
-        metadata = {
-            "trace-id": trace_id,
-            "parent-id": parent_id,
-            "sampling-priority": sampling_priority,
-        }
-        dd_trace_context = metadata.copy()
+        dd_trace_context = context
         trace_context_source = TraceContextSource.EVENT
     else:
         # AWS Lambda runtime caches global variables between invocations,
@@ -579,8 +494,8 @@ def get_dd_trace_context():
     """
     if dd_tracing_enabled:
         dd_trace_py_context = _get_dd_trace_py_context()
-        if dd_trace_py_context is not None:
-            return _context_obj_to_headers(dd_trace_py_context)
+        if _is_context_complete(dd_trace_py_context):
+            return dd_trace_py_context
 
     global dd_trace_context
 
@@ -592,16 +507,17 @@ def get_dd_trace_context():
             % e
         )
     if not xray_context:
-        return {}
+        return None
 
-    if not dd_trace_context:
-        return _context_obj_to_headers(xray_context)
+    if not _is_context_complete(dd_trace_context):
+        return xray_context
 
-    context = dd_trace_context.copy()
-    context["parent-id"] = xray_context.get("parent-id")
-    logger.debug("Set parent id from xray trace context: %s", context.get("parent-id"))
-
-    return _context_obj_to_headers(context)
+    logger.debug("Set parent id from xray trace context: %s", xray_context.span_id)
+    return Context(
+        trace_id=dd_trace_context.trace_id,
+        span_id=xray_context.span_id,
+        sampling_priority=dd_trace_context.sampling_priority,
+    )
 
 
 def set_correlation_ids():
@@ -620,13 +536,11 @@ def set_correlation_ids():
         return
 
     context = get_dd_trace_context()
-    if not context:
+    if not _is_context_complete(context):
         return
 
-    span = tracer.trace("dummy.span")
-    span.trace_id = int(context[TraceHeader.TRACE_ID])
-    span.span_id = int(context[TraceHeader.PARENT_ID])
-
+    tracer.context_provider.activate(context)
+    tracer.trace("dummy.span")
     logger.debug("correlation ids set")
 
 
@@ -669,18 +583,20 @@ def is_lambda_context():
 
 def set_dd_trace_py_root(trace_context_source, merge_xray_traces):
     if trace_context_source == TraceContextSource.EVENT or merge_xray_traces:
-        context = dict(dd_trace_context)
+        context = Context(
+            trace_id=dd_trace_context.trace_id,
+            span_id=dd_trace_context.span_id,
+            sampling_priority=dd_trace_context.sampling_priority,
+        )
         if merge_xray_traces:
             xray_context = _get_xray_trace_context()
-            if xray_context is not None:
-                context["parent-id"] = xray_context.get("parent-id")
+            if xray_context.span_id:
+                context.span_id = xray_context.span_id
 
-        headers = _context_obj_to_headers(context)
-        span_context = propagator.extract(headers)
-        tracer.context_provider.activate(span_context)
+        tracer.context_provider.activate(context)
         logger.debug(
             "Set dd trace root context to: %s",
-            (span_context.trace_id, span_context.span_id),
+            (context.trace_id, context.span_id),
         )
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -118,21 +118,15 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         lambda_ctx = get_mock_context()
         ctx, source, event_source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "xray")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": fake_xray_header_value_root_decimal,
-                "parent-id": fake_xray_header_value_parent_decimal,
-                "sampling-priority": "2",
-            },
+        expected_context = Context(
+            trace_id=fake_xray_header_value_root_decimal,
+            span_id=fake_xray_header_value_parent_decimal,
+            sampling_priority="2",
         )
-        self.assertDictEqual(
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: fake_xray_header_value_root_decimal,
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "2",
-            },
+            expected_context,
             {},
         )
 
@@ -140,21 +134,15 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         lambda_ctx = get_mock_context()
         ctx, source, event_source = extract_dd_trace_context(b"", lambda_ctx)
         self.assertEqual(source, "xray")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": fake_xray_header_value_root_decimal,
-                "parent-id": fake_xray_header_value_parent_decimal,
-                "sampling-priority": "2",
-            },
+        expected_context = Context(
+            trace_id=fake_xray_header_value_root_decimal,
+            span_id=fake_xray_header_value_parent_decimal,
+            sampling_priority="2",
         )
-        self.assertDictEqual(
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: fake_xray_header_value_root_decimal,
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "2",
-            },
+            expected_context,
             {},
         )
 
@@ -165,22 +153,13 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             lambda_ctx,
         )
         self.assertEqual(source, "xray")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": fake_xray_header_value_root_decimal,
-                "parent-id": fake_xray_header_value_parent_decimal,
-                "sampling-priority": "2",
-            },
+        expected_context = Context(
+            trace_id=fake_xray_header_value_root_decimal,
+            span_id=fake_xray_header_value_parent_decimal,
+            sampling_priority="2",
         )
-        self.assertDictEqual(
-            get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: fake_xray_header_value_root_decimal,
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "2",
-            },
-        )
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(get_dd_trace_context(), expected_context)
 
     def test_with_complete_datadog_trace_headers(self):
         lambda_ctx = get_mock_context()
@@ -195,23 +174,21 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             lambda_ctx,
         )
         self.assertEqual(source, "event")
-        self.assertDictEqual(
-            ctx,
-            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
-        )
-        self.assertDictEqual(
+        expected_context = Context(trace_id=123, span_id=321, sampling_priority=1)
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "123",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id=123,
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority=1,
+            ),
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called()
         self.mock_send_segment.assert_called_with(
             XraySubsegment.TRACE_KEY,
-            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
+            expected_context,
         )
 
     def test_with_extractor_function(self):
@@ -237,21 +214,21 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             extractor=extractor_foo,
         )
         self.assertEqual(ctx_source, "event")
-        self.assertDictEqual(
+        self.assertEqual(
             ctx,
-            {
-                "trace-id": "123",
-                "parent-id": "321",
-                "sampling-priority": "1",
-            },
+            Context(
+                trace_id="123",
+                span_id="321",
+                sampling_priority="1",
+            ),
         )
-        self.assertDictEqual(
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "123",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id="123",
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority="1",
+            ),
         )
 
     def test_graceful_fail_of_extractor_function(self):
@@ -271,22 +248,13 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             extractor=extractor_raiser,
         )
         self.assertEqual(ctx_source, "xray")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": fake_xray_header_value_root_decimal,
-                "parent-id": fake_xray_header_value_parent_decimal,
-                "sampling-priority": "2",
-            },
+        expected_context = Context(
+            trace_id=fake_xray_header_value_root_decimal,
+            span_id=fake_xray_header_value_parent_decimal,
+            sampling_priority="2",
         )
-        self.assertDictEqual(
-            get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: fake_xray_header_value_root_decimal,
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "2",
-            },
-        )
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(get_dd_trace_context(), expected_context)
 
     def test_with_sqs_distributed_datadog_trace_data(self):
         lambda_ctx = get_mock_context()
@@ -323,26 +291,24 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         }
         ctx, source, event_source = extract_dd_trace_context(sqs_event, lambda_ctx)
         self.assertEqual(source, "event")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "123",
-                "parent-id": "321",
-                "sampling-priority": "1",
-            },
+        expected_context = Context(
+            trace_id=123,
+            span_id=321,
+            sampling_priority=1,
         )
-        self.assertDictEqual(
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "123",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id=123,
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority=1,
+            ),
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called_with(
             XraySubsegment.TRACE_KEY,
-            {"trace-id": "123", "parent-id": "321", "sampling-priority": "1"},
+            expected_context,
         )
 
     def test_with_legacy_client_context_datadog_trace_data(self):
@@ -357,27 +323,25 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         ctx, source, event_source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "666",
-                "parent-id": "777",
-                "sampling-priority": "1",
-            },
+        expected_context = Context(
+            trace_id=666,
+            span_id=777,
+            sampling_priority=1,
         )
-        self.assertDictEqual(
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "666",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id=666,
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority=1,
+            ),
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called()
         self.mock_send_segment.assert_called_with(
             XraySubsegment.TRACE_KEY,
-            {"trace-id": "666", "parent-id": "777", "sampling-priority": "1"},
+            expected_context,
         )
 
     def test_with_new_client_context_datadog_trace_data(self):
@@ -390,27 +354,25 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         )
         ctx, source, event_source = extract_dd_trace_context({}, lambda_ctx)
         self.assertEqual(source, "event")
-        self.assertDictEqual(
-            ctx,
-            {
-                "trace-id": "666",
-                "parent-id": "777",
-                "sampling-priority": "1",
-            },
+        expected_context = Context(
+            trace_id=666,
+            span_id=777,
+            sampling_priority=1,
         )
-        self.assertDictEqual(
+        self.assertEqual(ctx, expected_context)
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "666",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id=666,
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority=1,
+            ),
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called()
         self.mock_send_segment.assert_called_with(
             XraySubsegment.TRACE_KEY,
-            {"trace-id": "666", "parent-id": "777", "sampling-priority": "1"},
+            expected_context,
         )
 
     def test_with_complete_datadog_trace_headers_with_mixed_casing(self):
@@ -425,13 +387,13 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             },
             lambda_ctx,
         )
-        self.assertDictEqual(
+        self.assertEqual(
             get_dd_trace_context(),
-            {
-                TraceHeader.TRACE_ID: "123",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
-                TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+            Context(
+                trace_id=123,
+                span_id=fake_xray_header_value_parent_decimal,
+                sampling_priority=1,
+            ),
         )
 
     def test_with_complete_datadog_trace_headers_with_trigger_tags(self):
@@ -496,10 +458,11 @@ class TestLogsInjection(unittest.TestCase):
     def setUp(self):
         patcher = patch("datadog_lambda.tracing.get_dd_trace_context")
         self.mock_get_dd_trace_context = patcher.start()
-        self.mock_get_dd_trace_context.return_value = {
-            TraceHeader.TRACE_ID: "123",
-            TraceHeader.PARENT_ID: "456",
-        }
+        self.mock_get_dd_trace_context.return_value = Context(
+            trace_id=int(fake_xray_header_value_root_decimal),
+            span_id=int(fake_xray_header_value_parent_decimal),
+            sampling_priority=1,
+        )
         self.addCleanup(patcher.stop)
 
         patcher = patch("datadog_lambda.tracing.is_lambda_context")
@@ -510,13 +473,14 @@ class TestLogsInjection(unittest.TestCase):
     def test_set_correlation_ids(self):
         set_correlation_ids()
         span = tracer.current_span()
-        self.assertEqual(span.trace_id, 123)
-        self.assertEqual(span.span_id, 456)
+        self.assertEqual(span.trace_id, int(fake_xray_header_value_root_decimal))
+        # XXX: used to be span.span_id
+        self.assertEqual(span.parent_id, int(fake_xray_header_value_parent_decimal))
         span.finish()
 
     def test_set_correlation_ids_handle_empty_trace_context(self):
         # neither x-ray or ddtrace is used. no tracing context at all.
-        self.mock_get_dd_trace_context.return_value = {}
+        self.mock_get_dd_trace_context.return_value = Context()
         # no exception thrown
         set_correlation_ids()
         span = tracer.current_span()
@@ -620,7 +584,7 @@ class TestSetTraceRootSpan(unittest.TestCase):
 
         expected_context = Context(
             trace_id=123,  # Trace Id from incomming context
-            span_id=int(fake_xray_header_value_parent_decimal),  # Parent Id from x-ray
+            span_id=fake_xray_header_value_parent_decimal,  # Parent Id from x-ray
             sampling_priority=1,  # Sampling priority from incomming context
         )
         self.mock_activate.assert_called()
@@ -1829,10 +1793,10 @@ class TestInferredSpans(unittest.TestCase):
         with open(test_file, "r") as event:
             event = json.load(event)
         ctx = get_mock_context()
-        trace, parent, sampling = extract_context_from_eventbridge_event(event, ctx)
-        self.assertEqual(trace, "12345")
-        self.assertEqual(parent, "67890"),
-        self.assertEqual(sampling, "2")
+        context = extract_context_from_eventbridge_event(event, ctx)
+        self.assertEqual(context.trace_id, 12345)
+        self.assertEqual(context.span_id, 67890),
+        self.assertEqual(context.sampling_priority, 2)
 
     def test_extract_dd_trace_context_for_eventbridge(self):
         event_sample_source = "eventbridge-custom"
@@ -1841,8 +1805,8 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_type = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "12345")
-        self.assertEqual(context["parent-id"], "67890")
+        self.assertEqual(context.trace_id, 12345)
+        self.assertEqual(context.span_id, 67890)
 
     def test_extract_context_from_eventbridge_sqs_event(self):
         event_sample_source = "eventbridge-sqs"
@@ -1852,9 +1816,9 @@ class TestInferredSpans(unittest.TestCase):
 
         ctx = get_mock_context()
         context, source, event_type = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "7379586022458917877")
-        self.assertEqual(context["parent-id"], "2644033662113726488")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 7379586022458917877)
+        self.assertEqual(context.span_id, 2644033662113726488)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_sqs_event_with_string_msg_attr(self):
         event_sample_source = "sqs-string-msg-attribute"
@@ -1863,9 +1827,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_type = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "2684756524522091840")
-        self.assertEqual(context["parent-id"], "7431398482019833808")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 2684756524522091840)
+        self.assertEqual(context.span_id, 7431398482019833808)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_sqs_batch_event(self):
         event_sample_source = "sqs-batch"
@@ -1874,9 +1838,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "2684756524522091840")
-        self.assertEqual(context["parent-id"], "7431398482019833808")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 2684756524522091840)
+        self.assertEqual(context.span_id, 7431398482019833808)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_sns_event_with_string_msg_attr(self):
         event_sample_source = "sns-string-msg-attribute"
@@ -1885,9 +1849,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "4948377316357291421")
-        self.assertEqual(context["parent-id"], "6746998015037429512")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 4948377316357291421)
+        self.assertEqual(context.span_id, 6746998015037429512)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_sns_event_with_b64_msg_attr(self):
         event_sample_source = "sns-b64-msg-attribute"
@@ -1896,9 +1860,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "4948377316357291421")
-        self.assertEqual(context["parent-id"], "6746998015037429512")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 4948377316357291421)
+        self.assertEqual(context.span_id, 6746998015037429512)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_sns_batch_event(self):
         event_sample_source = "sns-batch"
@@ -1907,9 +1871,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "4948377316357291421")
-        self.assertEqual(context["parent-id"], "6746998015037429512")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 4948377316357291421)
+        self.assertEqual(context.span_id, 6746998015037429512)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_kinesis_event(self):
         event_sample_source = "kinesis"
@@ -1918,9 +1882,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "4948377316357291421")
-        self.assertEqual(context["parent-id"], "2876253380018681026")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 4948377316357291421)
+        self.assertEqual(context.span_id, 2876253380018681026)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_extract_context_from_kinesis_batch_event(self):
         event_sample_source = "kinesis-batch"
@@ -1929,9 +1893,9 @@ class TestInferredSpans(unittest.TestCase):
             event = json.load(event)
         ctx = get_mock_context()
         context, source, event_source = extract_dd_trace_context(event, ctx)
-        self.assertEqual(context["trace-id"], "4948377316357291421")
-        self.assertEqual(context["parent-id"], "2876253380018681026")
-        self.assertEqual(context["sampling-priority"], "1")
+        self.assertEqual(context.trace_id, 4948377316357291421)
+        self.assertEqual(context.span_id, 2876253380018681026)
+        self.assertEqual(context.sampling_priority, 1)
 
     def test_create_inferred_span_from_api_gateway_event_no_apiid(self):
         event_sample_source = "api-gateway-no-apiid"


### PR DESCRIPTION
[SVLS-3936]
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Instead of manually extracting trace context from inbound payloads, defer that responsibility to dd-trace-py. This allows us to support w3c trace context headers.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

Support for w3c trace context headers, why implement this extraction when the tracer has already done it.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)


[SVLS-3936]: https://datadoghq.atlassian.net/browse/SVLS-3936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ