### PR TITLE
Improve error log message when no sns->sqs context found.

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -266,6 +266,7 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
                 "Datadog Lambda Python only supports extracting trace"
                 "context from String or Binary SQS/SNS message attributes"
             )
+            return extract_context_from_lambda_context(lambda_context)
         dd_data = json.loads(dd_json_data)
         return propagator.extract(dd_data)
     except Exception as e:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Instead of logging

```
Datadog Lambda Python only supports extracting trace context from String or Binary SQS/SNS message attributes

The tracer extractor returned with error local variable 'dd_json_data' referenced before assignment
```

log 

```
The tracer extractor returned with error Datadog Lambda Python only supports extracting trace context from String or Binary SQS/SNS message attributes
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
