### PR TITLE
Use xray context span id when it exists

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -89,7 +89,7 @@ def _convert_xray_sampling(xray_sampled):
     return SamplingPriority.USER_KEEP if xray_sampled else SamplingPriority.USER_REJECT
 
 
-def _get_xray_trace_context():
+def _get_xray_trace_context() -> Optional[Context]:
     if not is_lambda_context():
         return None
 
@@ -604,7 +604,7 @@ def set_dd_trace_py_root(trace_context_source, merge_xray_traces):
         )
         if merge_xray_traces:
             xray_context = _get_xray_trace_context()
-            if xray_context.span_id:
+            if xray_context and xray_context.span_id:
                 context.span_id = xray_context.span_id
 
         tracer.context_provider.activate(context)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Address conditional runtime error when the xray context doesn't exist.

### Motivation

Encountered this error when running the extension on a lambda with SAM local.

```
[ERROR] 2023-11-29T01:44:35.868Z        56c0ddf8-9de9-4006-89a0-e46b7cace0f8    Error 'NoneType' object has no attribute 'span_id'. Traceback: Traceback (most recent call last):
  File "/var/task/datadog_lambda/wrapper.py", line 288, in _before
    set_dd_trace_py_root(trace_context_source, self.merge_xray_traces)
  File "/var/task/datadog_lambda/tracing.py", line 607, in set_dd_trace_py_root
    if xray_context.span_id:
AttributeError: 'NoneType' object has no attribute 'span_id'
```


### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
