### PR TITLE
Ensure dummy metadata segment is json serializable.

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -281,7 +281,12 @@ class _LambdaDecorator(object):
             # Create a Datadog X-Ray subsegment with the trace context
             if dd_context and trace_context_source == TraceContextSource.EVENT:
                 create_dd_dummy_metadata_subsegment(
-                    dd_context, XraySubsegment.TRACE_KEY
+                    {
+                        "trace-id": str(dd_context.trace_id),
+                        "parent-id": str(dd_context.span_id),
+                        "sampling-priority": str(dd_context.sampling_priority),
+                    },
+                    XraySubsegment.TRACE_KEY,
                 )
 
             if dd_tracing_enabled:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -9,7 +9,7 @@ from datadog_lambda.constants import TraceHeader
 import datadog_lambda.wrapper as wrapper
 from datadog_lambda.metric import lambda_metric
 from datadog_lambda.thread_stats_writer import ThreadStatsWriter
-from ddtrace import Span
+from ddtrace import Span, tracer
 
 
 def get_mock_context(
@@ -580,3 +580,70 @@ class TestLambdaDecoratorSettings(unittest.TestCase):
         self.assertFalse(decorator.make_inferred_span)
         self.assertFalse(decorator.encode_authorizer_context)
         self.assertFalse(decorator.decode_authorizer_context)
+
+
+class TestLambdaWrapperWithTraceContext(unittest.TestCase):
+    xray_root = "1-5e272390-8c398be037738dc042009320"
+    xray_parent = "94ae789b969f1cc5"
+    xray_daemon_envvar = "localhost:1234"
+    xray_trace_envvar = (
+        f"Root={xray_root};Parent={xray_parent};Sampled=1;Lineage=c6c5b1b9:0"
+    )
+
+    @patch(
+        "os.environ",
+        {
+            "AWS_XRAY_DAEMON_ADDRESS": xray_daemon_envvar,
+            "_X_AMZN_TRACE_ID": xray_trace_envvar,
+        },
+    )
+    def test_event_bridge_sqs_payload(self):
+        patcher = patch("datadog_lambda.xray.send")
+        mock_send = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        def handler(event, context):
+            return tracer.current_trace_context()
+
+        wrapper.dd_tracing_enabled = True
+        wrapped_handler = wrapper.datadog_lambda_wrapper(handler)
+
+        event_trace_id = 3047453991382739997
+        event_parent_id = 3047453991382739997
+        event = {
+            "headers": {
+                "traceparent": (
+                    f"00-0000000000000000{hex(event_trace_id)[2:]}-{hex(event_parent_id)[2:]}-01"
+                ),
+                "tracestate": "dd=s:1;t.dm:-1",
+                "x-datadog-trace-id": str(event_trace_id),
+                "x-datadog-parent-id": str(event_parent_id),
+                "x-datadog-sampling-priority": "1",
+            },
+        }
+        context = get_mock_context()
+
+        result = wrapped_handler(event, context)
+        aws_lambda_span = wrapped_handler.span
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.trace_id, event_trace_id)
+        self.assertEqual(result.span_id, aws_lambda_span.span_id)
+        self.assertEqual(result.sampling_priority, 1)
+        mock_send.assert_called_once()
+        (_, raw_payload), _ = mock_send.call_args
+        payload = json.loads(raw_payload[33:])  # strip formatting prefix
+        self.assertEqual(self.xray_root, payload["trace_id"])
+        self.assertEqual(self.xray_parent, payload["parent_id"])
+        self.assertDictEqual(
+            {
+                "datadog": {
+                    "trace": {
+                        "trace-id": str(event_trace_id),
+                        "parent-id": str(event_parent_id),
+                        "sampling-priority": "1",
+                    },
+                },
+            },
+            payload["metadata"],
+        )


### PR DESCRIPTION
Fixes error `TypeError: Object of type Context is not JSON serializable` https://github.com/DataDog/datadog-lambda-python/issues/402

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes https://github.com/DataDog/datadog-lambda-python/issues/402

When creating the xray metadata subsegment, we must pass a json serializable object. Unfortunately, a `ddtrace.context.Context` object is not json serializable.

Because the `create_dd_dummy_metadata_subsegment` method is used in other locations as well, we must convert the `ddtrace.context.Context` object before calling this method.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

The test that I added passes with v82 of the layer but fails with v83 and v84. The fact that it again passes indicates to me that this fix will work.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
