### PR TITLE
Use one connection for all communication with extension.

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -10,7 +10,7 @@ from importlib import import_module
 import json
 from time import time_ns
 
-from datadog_lambda.extension import should_use_extension, flush_extension
+from datadog_lambda.extension import should_use_extension
 from datadog_lambda.cold_start import (
     set_cold_start,
     is_cold_start,
@@ -367,8 +367,6 @@ class _LambdaDecorator(object):
 
             if not self.flush_to_log or should_use_extension:
                 flush_stats()
-            if should_use_extension:
-                flush_extension()
 
             if self.encode_authorizer_context and is_authorizer_response(self.response):
                 self._inject_authorizer_span_headers(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Changes all communication with the extension to using a persistent http connection.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This change reduces runtime duration by somewhere between 5-10%.

<img width="1312" alt="Screenshot 2023-12-14 at 10 01 45 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/1383216/d9cb0646-1796-45bc-90bc-49c74928fd3a">

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

⚠️ This is a high risk change. Sufficient testing must be done before merging! ⚠️ 

As I run tests on this branch, I will post the results below as comments.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
