### PR TITLE
chore: allow builds to use specified architecture

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -15,6 +15,21 @@ set -e
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_py"
 AVAILABLE_PYTHON_VERSIONS=("3.8" "3.9" "3.10" "3.11" "3.12")
+AVAILABLE_ARCHS=("arm64" "amd64")
+
+if [ -z "$ARCH" ]; then
+    echo "No architectures specified, building layers for all architectures."
+    ARCHS=("${AVAILABLE_ARCHS[@]}")
+else
+    echo "Architecture specified: $ARCH"
+    if [[ ! " ${AVAILABLE_ARCHS[@]} " =~ " ${ARCH} " ]]; then
+        echo "Architecture $ARCH is not a valid option. Choose from: ${AVAILABLE_ARCHS[@]}"
+        echo ""
+        echo "EXITING SCRIPT."
+        exit 1
+    fi
+    ARCHS=$ARCH
+fi
 
 # Determine which Python versions to build layers for
 if [ -z "$PYTHON_VERSION" ]; then
@@ -64,10 +79,11 @@ mkdir $LAYER_DIR
 
 for python_version in "${PYTHON_VERSIONS[@]}"
 do
-    echo "Building layer for Python ${python_version} arch=arm64"
-    docker_build_zip ${python_version} $LAYER_DIR/${LAYER_FILES_PREFIX}-arm64-${python_version}.zip arm64
-    echo "Building layer for Python ${python_version} arch=amd64"
-    docker_build_zip ${python_version} $LAYER_DIR/${LAYER_FILES_PREFIX}-amd64-${python_version}.zip amd64
+    for architecture in "${ARCHS[@]}"
+    do
+        echo "Building layer for Python ${python_version} arch=${architecture}"
+        docker_build_zip ${python_version} $LAYER_DIR/${LAYER_FILES_PREFIX}-${architecture}-${python_version}.zip ${architecture}
+    done
 done
 
 echo "Done creating layers:"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allows the build layers script to use architecture if specified.

### Motivation

Currently it builds for both runtimes if not specified, its slowing down GitLab jobs.

### Testing Guidelines

n/a

### Additional Notes

Usage is
```bash
PYTHON_VERSION=3.10 ARCH=amd64 ./scripts/build_layers
```
Will build `3.10` on `amd64`.
Any other value besides `arm64|amd64` will fail.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
