### PR TITLE
Disable API security by default

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,5 +1,13 @@
 from datadog_lambda.cold_start import initialize_cold_start_tracing
 from datadog_lambda.logger import initialize_logging
+import os
+
+
+if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED") is None:
+    os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
+
+if os.environ.get("DD_API_SECURITY_ENABLED") is None:
+    os.environ["DD_API_SECURITY_ENABLED"] = "False"
 
 initialize_cold_start_tracing()
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -29,9 +29,6 @@ from datadog_lambda.xray import (
     parse_xray_header,
 )
 
-if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED") is None:
-    os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
-
 from ddtrace import tracer, patch, Span
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This was enabled by default in dd-trace-py, but doesn't apply to lambda and is responsible for about a 128ms cold start increase.
This will disable it unless the user explicitly opts-in.

### Motivation
I want this to go fast.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
