### PR TITLE
feat: Signing job should run as one-shot or loop over layers

### DIFF
--- a/scripts/sign_layers.sh
+++ b/scripts/sign_layers.sh
@@ -41,6 +41,18 @@ if [ "$1" = "prod" ]; then
     S3_BUCKET_NAME="dd-lambda-signing-bucket"
 fi
 
+if [ -z "$LAYER_FILE" ]; then
+    echo "Layer file not specified, running for all layer files."
+else
+    echo "Layer file is specified: $LAYER_FILE"
+    if (printf '%s\n' "${LAYER_FILES[@]}" | grep -xq $LAYER_FILE); then
+        LAYER_FILES=($LAYER_FILE)
+    else
+        echo "Unsupported layer found, valid options are : ${LAYER_FILES[@]}"
+        exit 1
+    fi
+fi
+
 for LAYER_FILE in "${LAYER_FILES[@]}"
 do
     echo


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
The signing job now runs a layer in one shot as part of a generated matrix, but for govcloud it also must run for all supported runtimes.
This allows it to do both.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
