### PR TITLE
feat: Bump ddtrace to 2.7.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -22,18 +22,18 @@ tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "p
 
 [[package]]
 name = "boto3"
-version = "1.34.28"
+version = "1.34.59"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.28-py3-none-any.whl", hash = "sha256:fb56622ce195c06ae0d15ae9472d44529362a869ad52862a5a28b891530969f9"},
-    {file = "boto3-1.34.28.tar.gz", hash = "sha256:9e0dcca7bb0567f7b4b84d1d26c19b217abfe149d19106af7f120f09142688cf"},
+    {file = "boto3-1.34.59-py3-none-any.whl", hash = "sha256:004e67b078be58d34469406f93cc8b95bc43becef4bbe44523a0b8e51f84c668"},
+    {file = "boto3-1.34.59.tar.gz", hash = "sha256:162edf182e53c198137a28432a626dba103f787a8f5000ed4758b73ccd203fa0"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.28,<1.35.0"
+botocore = ">=1.34.59,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -42,14 +42,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.28"
+version = "1.34.59"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.28-py3-none-any.whl", hash = "sha256:03be8209257ab65f3c8be7377cf8d38bff6a6afbe3d36c72924e48959bb694dc"},
-    {file = "botocore-1.34.28.tar.gz", hash = "sha256:45c99ccc6389ab1a87e996a7cc8797c7e41d5ecd9a5757d567ba3a57cb7655e7"},
+    {file = "botocore-1.34.59-py3-none-any.whl", hash = "sha256:4bc112dafb1679ab571117593f7656604726a3da0e5ae5bad00ea772fa40e75c"},
+    {file = "botocore-1.34.59.tar.gz", hash = "sha256:24edb4d21d7c97dea0c6c4a80d36b3809b1443a30b0bd5e317d6c319dfac823f"},
 ]
 
 [package.dependencies]
@@ -106,14 +106,14 @@ ujson = ["ujson (>=5.7.0)"]
 
 [[package]]
 name = "certifi"
-version = "2023.11.17"
+version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
-    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
+    {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
+    {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
 ]
 
 [[package]]
@@ -217,69 +217,16 @@ files = [
 ]
 
 [[package]]
-name = "coverage"
-version = "7.4.1"
-description = "Code coverage measurement for Python"
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
 category = "main"
 optional = true
-python-versions = ">=3.8"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
-    {file = "coverage-7.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:077d366e724f24fc02dbfe9d946534357fda71af9764ff99d73c3c596001bbd7"},
-    {file = "coverage-7.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0193657651f5399d433c92f8ae264aff31fc1d066deee4b831549526433f3f61"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d17bbc946f52ca67adf72a5ee783cd7cd3477f8f8796f59b4974a9b59cacc9ee"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3277f5fa7483c927fe3a7b017b39351610265308f5267ac6d4c2b64cc1d8d25"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dceb61d40cbfcf45f51e59933c784a50846dc03211054bd76b421a713dcdf19"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6008adeca04a445ea6ef31b2cbaf1d01d02986047606f7da266629afee982630"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c61f66d93d712f6e03369b6a7769233bfda880b12f417eefdd4f16d1deb2fc4c"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9bb62fac84d5f2ff523304e59e5c439955fb3b7f44e3d7b2085184db74d733b"},
-    {file = "coverage-7.4.1-cp310-cp310-win32.whl", hash = "sha256:f86f368e1c7ce897bf2457b9eb61169a44e2ef797099fb5728482b8d69f3f016"},
-    {file = "coverage-7.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:869b5046d41abfea3e381dd143407b0d29b8282a904a19cb908fa24d090cc018"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ffb498a83d7e0305968289441914154fb0ef5d8b3157df02a90c6695978295"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cacfaefe6089d477264001f90f55b7881ba615953414999c46cc9713ff93c8c"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d6850e6e36e332d5511a48a251790ddc545e16e8beaf046c03985c69ccb2676"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18e961aa13b6d47f758cc5879383d27b5b3f3dcd9ce8cdbfdc2571fe86feb4dd"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfd1e1b9f0898817babf840b77ce9fe655ecbe8b1b327983df485b30df8cc011"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b00e21f86598b6330f0019b40fb397e705135040dbedc2ca9a93c7441178e74"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:536d609c6963c50055bab766d9951b6c394759190d03311f3e9fcf194ca909e1"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7ac8f8eb153724f84885a1374999b7e45734bf93a87d8df1e7ce2146860edef6"},
-    {file = "coverage-7.4.1-cp311-cp311-win32.whl", hash = "sha256:f3771b23bb3675a06f5d885c3630b1d01ea6cac9e84a01aaf5508706dba546c5"},
-    {file = "coverage-7.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:9d2f9d4cc2a53b38cabc2d6d80f7f9b7e3da26b2f53d48f05876fef7956b6968"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f68ef3660677e6624c8cace943e4765545f8191313a07288a53d3da188bd8581"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23b27b8a698e749b61809fb637eb98ebf0e505710ec46a8aa6f1be7dc0dc43a6"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3424c554391dc9ef4a92ad28665756566a28fecf47308f91841f6c49288e66"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0860a348bf7004c812c8368d1fc7f77fe8e4c095d661a579196a9533778e156"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe558371c1bdf3b8fa03e097c523fb9645b8730399c14fe7721ee9c9e2a545d3"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3468cc8720402af37b6c6e7e2a9cdb9f6c16c728638a2ebc768ba1ef6f26c3a1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:02f2edb575d62172aa28fe00efe821ae31f25dc3d589055b3fb64d51e52e4ab1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ca6e61dc52f601d1d224526360cdeab0d0712ec104a2ce6cc5ccef6ed9a233bc"},
-    {file = "coverage-7.4.1-cp312-cp312-win32.whl", hash = "sha256:ca7b26a5e456a843b9b6683eada193fc1f65c761b3a473941efe5a291f604c74"},
-    {file = "coverage-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:85ccc5fa54c2ed64bd91ed3b4a627b9cce04646a659512a051fa82a92c04a448"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8bdb0285a0202888d19ec6b6d23d5990410decb932b709f2b0dfe216d031d218"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:918440dea04521f499721c039863ef95433314b1db00ff826a02580c1f503e45"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:379d4c7abad5afbe9d88cc31ea8ca262296480a86af945b08214eb1a556a3e4d"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b094116f0b6155e36a304ff912f89bbb5067157aff5f94060ff20bbabdc8da06"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2f5968608b1fe2a1d00d01ad1017ee27efd99b3437e08b83ded9b7af3f6f766"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:10e88e7f41e6197ea0429ae18f21ff521d4f4490aa33048f6c6f94c6045a6a75"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a4a3907011d39dbc3e37bdc5df0a8c93853c369039b59efa33a7b6669de04c60"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6d224f0c4c9c98290a6990259073f496fcec1b5cc613eecbd22786d398ded3ad"},
-    {file = "coverage-7.4.1-cp38-cp38-win32.whl", hash = "sha256:23f5881362dcb0e1a92b84b3c2809bdc90db892332daab81ad8f642d8ed55042"},
-    {file = "coverage-7.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:a07f61fc452c43cd5328b392e52555f7d1952400a1ad09086c4a8addccbd138d"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8e738a492b6221f8dcf281b67129510835461132b03024830ac0e554311a5c54"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46342fed0fff72efcda77040b14728049200cbba1279e0bf1188f1f2078c1d70"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9641e21670c68c7e57d2053ddf6c443e4f0a6e18e547e86af3fad0795414a628"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2c2688ed93b027eb0d26aa188ada34acb22dceea256d76390eea135083950"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12c923757de24e4e2110cf8832d83a886a4cf215c6e61ed506006872b43a6d1"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0491275c3b9971cdbd28a4595c2cb5838f08036bca31765bad5e17edf900b2c7"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8dfc5e195bbef80aabd81596ef52a1277ee7143fe419efc3c4d8ba2754671756"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1a78b656a4d12b0490ca72651fe4d9f5e07e3c6461063a9b6265ee45eb2bdd35"},
-    {file = "coverage-7.4.1-cp39-cp39-win32.whl", hash = "sha256:f90515974b39f4dea2f27c0959688621b46d96d5a626cf9c53dbc653a895c05c"},
-    {file = "coverage-7.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:64e723ca82a84053dd7bfcc986bdb34af8d9da83c521c19d6b472bc6880e191a"},
-    {file = "coverage-7.4.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:32a8d985462e37cfdab611a6f95b09d7c091d07668fdc26e47a725ee575fe166"},
-    {file = "coverage-7.4.1.tar.gz", hash = "sha256:1ed4b95480952b1a26d863e546fa5094564aa0065e1e5f0d4d0041f293251d04"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-
-[package.extras]
-toml = ["tomli"]
 
 [[package]]
 name = "datadog"
@@ -314,72 +261,72 @@ six = "*"
 
 [[package]]
 name = "ddtrace"
-version = "2.5.1"
+version = "2.7.2"
 description = "Datadog APM client library"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ddtrace-2.5.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:3bb27b10bcb55ad392027ac37ddc86cbea04e38f9963b18e4b7218a59dbc9b6d"},
-    {file = "ddtrace-2.5.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:bde40dd9cdff53de6535f9ae1e41a4d37aed0eb113e4597fde8f48dec4629291"},
-    {file = "ddtrace-2.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e02e3d15c2a3b63bd5a05fed429f7d77d41bc818b7a18554ac0f36104de28ccf"},
-    {file = "ddtrace-2.5.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e746cb76c41602173ed1d995929218c23cd41f52f29ac2cdf6d44f04b593a5b1"},
-    {file = "ddtrace-2.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f98240890feca039ce05310bbe91cb842dfc43277ca0560e6acd483753a90cbd"},
-    {file = "ddtrace-2.5.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ae7ed838023ce3d30d2cd071bd6113525b6245e8c25c1f8f9ff32b76fb7b7394"},
-    {file = "ddtrace-2.5.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e4b2ab5094e7d4cbf3a5143716e400b3b4af81e777e4afb30a9374394b7a8238"},
-    {file = "ddtrace-2.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:da1db3e7b5d45c54daf5b422333a03711dcdb448d7b122a689841c450797baa6"},
-    {file = "ddtrace-2.5.1-cp310-cp310-win32.whl", hash = "sha256:e0eda4c5f4cc7219361503fd05c1f0bbb6c70d73de73805d062becf323055ffc"},
-    {file = "ddtrace-2.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:aeb3a6358e702c7797fc6c447f2a2e5873dc207e65176bb6080608e7d2662a15"},
-    {file = "ddtrace-2.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aecb70d89e3662aa32fc42a271dcd90dde654902ccb97fbca2e5c52dfd10276d"},
-    {file = "ddtrace-2.5.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:dc81597a7bf44d48ce1317e1dd62b0329eea1cf3a22cb1730273593bd3cf9dc6"},
-    {file = "ddtrace-2.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79e9f9db08a0bd3751503d4e215e04780e5d59d084f43cb54cc35089c4e08c57"},
-    {file = "ddtrace-2.5.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d971804470cb34a3580dd701432721678c0c361c75bc580cf2588f42fd13f0b9"},
-    {file = "ddtrace-2.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8a936345d53f5290c9557eac5ac7d90218cd45e7c92215f1ee3eb1de309fe46"},
-    {file = "ddtrace-2.5.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:eee1eb5ef049b8667d0d53cacfc3c79b5fe978acbd5a59135cd4e1ed59b31be9"},
-    {file = "ddtrace-2.5.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:56474f8756cb2a6b708c79a62227b5b0bc235d74099361a95ea225646dbbf230"},
-    {file = "ddtrace-2.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:06c8b33099285db7fb7dd4b6dffae16b7d88d13231b00104e29c85d925d7359d"},
-    {file = "ddtrace-2.5.1-cp311-cp311-win32.whl", hash = "sha256:209ac6ad4656869aecaa7794444d166c741200330843f555f4f8161643ea7a8b"},
-    {file = "ddtrace-2.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:418685567d33a27ac476756d73dfa81c74d40099f28dc5af61e3ad8cdaa6596d"},
-    {file = "ddtrace-2.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3a27a5cd2eefe98243e185d26cba380960819f43b1d214c77af6ba15699cd8ae"},
-    {file = "ddtrace-2.5.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:16479b5e04bdb0400898a14b2208247955fd599f9809d7f84d5055557258b6f2"},
-    {file = "ddtrace-2.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea1a5f908abd988e6f70595c31f4a0be18bbd780558c506640ce2751397c9d19"},
-    {file = "ddtrace-2.5.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72593b98093d3de456cd47185e6dbb851b77b104cd108a16d6339ff3102c1581"},
-    {file = "ddtrace-2.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7d1f311779369537148c124528265a7d7d45f4a4ad5304d4919c13d6216eba0"},
-    {file = "ddtrace-2.5.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:06a2f4fe57eae9e5a54bd6cf7fad6e34c1c7205ce78a65c2eeb10bd00b610538"},
-    {file = "ddtrace-2.5.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:45fc94bfd615c1c64f05e55b760289638de7149020e517af8cefca5151efbbc3"},
-    {file = "ddtrace-2.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4d10f6e5113d757fef994b9d8db89c7fa270cbb8aec99b75527c460217e5f2a4"},
-    {file = "ddtrace-2.5.1-cp312-cp312-win32.whl", hash = "sha256:7500956f12f55f51199b96cdbc6724adb627576dc968c8d36dbc646fc91cd291"},
-    {file = "ddtrace-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3302bc89ccdecfbbd907766cbd4e083e5d0df1cf075cd49b07ae5f1c25987187"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:0c845623008231788aca5e8e27e215d638999de0a82af58a3eebef74b8dd3100"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:988582eb12ade7ba4f4bf4a09e5fde8f05a005ffc1784381fd258720354f80bb"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2110dea2b2390f799516cfe0611e4727939cf3139186668786ad57bbcea70f08"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d8adf00eec47ecd78216903b7c6ec23d533aa0302120ca35d6c35836d92e7ab"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:878eed15287aebcc7b776a40392dc1794b12999f561c5872489ad1426df87914"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1a83033183a1747190a7528de8eb9da70392e227288f6d32f57800747c9379cc"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:80b21572dbb3d781360987468cd03dacd49179dd703e66d4fdeb524369f94da3"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-win32.whl", hash = "sha256:7d7511a9933a087f4603fb4d9c09d0f8a23b8bfdc2c958d7b01d255795d9f087"},
-    {file = "ddtrace-2.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:69327a9d1488dee70bc6ba052c76bd2f73d52767de890edf2997c0e9b3711316"},
-    {file = "ddtrace-2.5.1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1427aa0914a20f18b5a7f075c7f1f3c79ded434cfe8fd658110ba43c0490488a"},
-    {file = "ddtrace-2.5.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:8152a850af06a10c631e8725bf677da2867705c2c4ea4bcd2911837798870050"},
-    {file = "ddtrace-2.5.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2277b3b468479d2cfdef597030b029b217528a5bf986e94b707b8a346e68dd21"},
-    {file = "ddtrace-2.5.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fafb2235b87141bddd03b38b225ef3468ec821d9c4e5fd0c42b1d27b30f6e9c9"},
-    {file = "ddtrace-2.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10fa3443168545286c140bfef7a59957c87d89971650788010a2e19352a8f65e"},
-    {file = "ddtrace-2.5.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:af0eccf9ac9d9e7557cf52d2bfe549ea02d3b41b81407ebd70a11b079d15a160"},
-    {file = "ddtrace-2.5.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:49347e198e82025679c82f8880e029e2dec80f48f6fcc2bd30d64865f6c8c98f"},
-    {file = "ddtrace-2.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:66dec725d1abf764736a73ee04e885128abb7d6c6ca0ef6935888ba5610ef292"},
-    {file = "ddtrace-2.5.1-cp38-cp38-win32.whl", hash = "sha256:cf0cd0b7e65efb91ffacf5987d73fd1505bead9162c05d4a7bc0ff009414621e"},
-    {file = "ddtrace-2.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:38a4419916ea6496aa6ee49c13280da825d9863e2a4bce98d6c6820da8d51678"},
-    {file = "ddtrace-2.5.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:5e2ed51c5fa9247fa3122d8f615c157d0955e2d673b1e76da2578ecf313eb6cf"},
-    {file = "ddtrace-2.5.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:8953b2c39a0ca5fb4d742df346a9ed53d100ac6d50c6fd68416eb6ebadf9025e"},
-    {file = "ddtrace-2.5.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d35cc4e93283ad3f6e96be99de1ba8adc7ef503d995a3dd7808aa242bbed28cc"},
-    {file = "ddtrace-2.5.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f79c16a430fc1b4fb18b881106368f09383f293abf5366d96c1155aad320a677"},
-    {file = "ddtrace-2.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf8d46467e456b0f2682952b4b3835e996aaae77e26455f150c35dde223ff0fb"},
-    {file = "ddtrace-2.5.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f73d297c4528c880c0d35a2e43f2c3703662e31a5e527a0d33ee9c20e7dba530"},
-    {file = "ddtrace-2.5.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ed4fcda36dd740693314bcaa4feddb566b2ccd835c3ac6aad42f36525280cc1e"},
-    {file = "ddtrace-2.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d535cdfc9e34e3a7972420c88a9c88f399619867f9774f09ff3f92a57136e199"},
-    {file = "ddtrace-2.5.1-cp39-cp39-win32.whl", hash = "sha256:1d7b4f7aeb9dffe357f00f516fa7c800c9a76ff29045edfb381ac1ee4a228b34"},
-    {file = "ddtrace-2.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bebae8b500c2b6d641d0a312b4a0c1e222c2ba093c3db6e4b38315a6c5f819da"},
-    {file = "ddtrace-2.5.1.tar.gz", hash = "sha256:c78da78418a658b1ba1880ffe6477874aa1f26a23f26db98e0f012b07a1d3998"},
+    {file = "ddtrace-2.7.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:31a0a4ffefdc6c20e9e4ef663b411ea66bd2a4113bec7f10292df00b75e883f3"},
+    {file = "ddtrace-2.7.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:fd148fce8c18a278b055f7e1b4c56e5b3214cd17fc42882dfb987826a00197d6"},
+    {file = "ddtrace-2.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0febe3be1c06b7b3ea64aa21d0a37bc06f9a4c3291e833e95687c10be459a2"},
+    {file = "ddtrace-2.7.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6cc7663f1c7d42f47266ae135b4ee16773e125417597e24da86bb78ecc82f85b"},
+    {file = "ddtrace-2.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06c6b7e6f153fb739de3da62cb9d99283a2669f8ebeb92238d272803939c7433"},
+    {file = "ddtrace-2.7.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a7879965428bb7c6abd020031ef3a5ffcc0104b7c15f021dcc0315bc421a721a"},
+    {file = "ddtrace-2.7.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5e3d33c43e8302c72d1b2b7a854d4a17c787973e61ec76cd7fc6434839aefc7c"},
+    {file = "ddtrace-2.7.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fcbb686d0ffe47df42fe092e020302c912c956da742cf4787e616c8f73a26c8b"},
+    {file = "ddtrace-2.7.2-cp310-cp310-win32.whl", hash = "sha256:f9a76c303cec59216b706186e2de38ae1d650405660277fed121c7658f320cf7"},
+    {file = "ddtrace-2.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:4385b4f4f8ec7313ead4d852d8dd50cae4c45f49b3893cc6aa4a64a3b3be93b8"},
+    {file = "ddtrace-2.7.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4dd90dc7c173edc32283b4f70937ea01ec43924a1b0af7ef6bbaa22076210860"},
+    {file = "ddtrace-2.7.2-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:923462adde72f363821c0c165ac78aa76236ae12022d44ad7c51b8870595bbaa"},
+    {file = "ddtrace-2.7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:190c4eefc1e3c0a7befd995bf10b51451ddd497fb636fd825d7f8527e28c5864"},
+    {file = "ddtrace-2.7.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5016bc73e92adef4017e8cf7fff8a49a2c0fad8dcac600459fa30f63dbab8be"},
+    {file = "ddtrace-2.7.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c230035c714ed9ea3dd16d65813f539ba9c30c87294107d5f77cdddad430a086"},
+    {file = "ddtrace-2.7.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1689277365728d5735931b98ef64115d958ab76fb698472e7d92a1f71bf0000b"},
+    {file = "ddtrace-2.7.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3e3a19ae9e8e2e6aff56aa93d73a0d72ce5530c1f0347b7ebba68b5c437efe49"},
+    {file = "ddtrace-2.7.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e03cf1787728ae01cb8cd0b474b09461d47afb15a2146b1753bee80a27568d86"},
+    {file = "ddtrace-2.7.2-cp311-cp311-win32.whl", hash = "sha256:081ba7c3d876c6dde6d3f8078205e3ae06932f0dbe5cb283f9bdc99052c262de"},
+    {file = "ddtrace-2.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:0299654ce610fe4d0f73b9c599bfaacd17537d1193cc7be95fb8e5238bed0ffa"},
+    {file = "ddtrace-2.7.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:283d1ed0d496e07b80ef372f5e78d5a5aa86a70b59b1a0039d655d5796d8cd37"},
+    {file = "ddtrace-2.7.2-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:a0e0ad2f20ce6942b3ceca0578be72416aacd6f63a7ef07de5a86ea524b16ad4"},
+    {file = "ddtrace-2.7.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2094747698d8ffd50339b4c8142923371272a4e919a1f56cc75e8cce868ff638"},
+    {file = "ddtrace-2.7.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd239ba8a9762ef1defb7bb5c70e8b488987b462936f6f9f70a6613b35376178"},
+    {file = "ddtrace-2.7.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82170d1d5153554dcfd475c0c1ab64f315cc7f00c5cf6c6bb471025b661ecc41"},
+    {file = "ddtrace-2.7.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3140f5db9313f6a14d02a9036f16a1d5311261daec2d90160db829d08593ce1e"},
+    {file = "ddtrace-2.7.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:134194fa8e8c14798374074c5472f33479cf5220dfccea79e1abaea7f57bdef2"},
+    {file = "ddtrace-2.7.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5ce6f31d785762b80a8a8d346bdd302f15977cf0b0e13f81f4fdbf7815bae2c4"},
+    {file = "ddtrace-2.7.2-cp312-cp312-win32.whl", hash = "sha256:0e6cd36d2373345863b3664f440b0255c1313e4f7ea3ac343de38ffe5402fa90"},
+    {file = "ddtrace-2.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:8ee761d7dfa01ccfeeb81215d16da27d0cfcc47a58a6b582dfd5816bccb64005"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:c3b55cb4fc6ec1994f7f1e44dfbf62f46069b16cebe8b26781a3b198c821591d"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7aa91a2c729f9187a75084b2a0fce23c63a8d3181e9c33a640e9e638ddbc7079"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4ce51a957f21ae997795a9a2e9f11fb988718417012e2a5765f74e157f3099a"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb0adacd1116b1043f92382fd3dc9e7deabd6d788c15c2b1e3b0f75c4adb711"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:99a6cf91b3ab290afac26fa61b81b746677b1627df12373919219fd562881c2d"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:d4f8ac0ac0970d65223247c879729c4c489e3cc69529b54e9dd2051efc68a007"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6052dd35bb0ec6d1023f0c4de9b0426a9e16d80fd8152d8eb8135e34bf41e1df"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-win32.whl", hash = "sha256:641e440ac175bb04e03e34543ed48a3ddfe4a393712c62deb2f2c78adb48db90"},
+    {file = "ddtrace-2.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:1687a40014873860b8c87a9a3e18dee51fa6a593e4758f973ed4cb8832b4e53a"},
+    {file = "ddtrace-2.7.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:d5529a7e4a083ec1388872c5a9b41b38622a7146d27d3bdee81d701f0ac6fc38"},
+    {file = "ddtrace-2.7.2-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:df4b51f39b260d8706fdf5417f3f94277f76b951cbbeabdb2b3a597d5f6cd0c1"},
+    {file = "ddtrace-2.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27c6e8c3b1bf642ca74afe985985450f2ca18e686ecb4f2e0ab978ae5fc03f8f"},
+    {file = "ddtrace-2.7.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0399c670229651517338c456304a2a65ce54387b8ddecf2da7011b259c0817d"},
+    {file = "ddtrace-2.7.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c81a89236f3ea91ad0e9da1fef32d9420c0d4614a44ef0a2cab168444cdb0d8"},
+    {file = "ddtrace-2.7.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:06d840db3283999ddacc3c9d8f5e5f0e0692ce635500d51f5e7e7ed2109c989a"},
+    {file = "ddtrace-2.7.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0e242cab1c2a153e418060f66e477e21b45cd33843959a6d000f3f9ea8a9c06a"},
+    {file = "ddtrace-2.7.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b51e2230d805873974af882c19026030f40aee14a8d1b55d378443659ff4463f"},
+    {file = "ddtrace-2.7.2-cp38-cp38-win32.whl", hash = "sha256:7c589ee49644d6c022928ebe49e4586b22ac40f8f841d67e01eeda4a6f61cea0"},
+    {file = "ddtrace-2.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:0974c8f36f0f1be229befede438ba91c1da715abd68091c0c0e21ec4d3d85f79"},
+    {file = "ddtrace-2.7.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b602703fff34f3397df22fdc1184fc039d89e8c5b07cc2bcc330c9b83bcc6ad6"},
+    {file = "ddtrace-2.7.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:81ff83a9cdc033175780379d83af4bb03785bfd3c71672954f00c5a7f8d0d63b"},
+    {file = "ddtrace-2.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6f7e2fa06c61f9a26b253898654a97b49b805942aee19fb7c4b95e17105c6a5"},
+    {file = "ddtrace-2.7.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0140acfd73449e8cfa090e322f76ff85f385ce4337111ed2780cd2ee62e5e4b"},
+    {file = "ddtrace-2.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9af429e4c48cae2fb6a9a51cdb6ccc2dc0cabbc9905c1ce6e9062335da0b9db"},
+    {file = "ddtrace-2.7.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:09330db7a2c0ed91d244ef653f0aa261153dc0820874923c325058352b5278fd"},
+    {file = "ddtrace-2.7.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8638ddb94d77bdf55cc64718af66b172c4ff677b57c9e59dfd9dc8f630fb3169"},
+    {file = "ddtrace-2.7.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0ba0668e439134b3f258ddcc3e5c1d1d8848a40954087288312557b455b6967e"},
+    {file = "ddtrace-2.7.2-cp39-cp39-win32.whl", hash = "sha256:aa3c927299aa134ccaf8821eb7284366c60e29a542d0e7738e0b7dd9182b2025"},
+    {file = "ddtrace-2.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:7e3f36e91d1a91fb083258b09fa7f887a295321b4dc928630ce748ec664e70be"},
+    {file = "ddtrace-2.7.2.tar.gz", hash = "sha256:89a0b4b30220aeb68c2845fa21e51ec9bf915a1893cf003850b9d8022e7cb72a"},
 ]
 
 [package.dependencies]
@@ -392,6 +339,7 @@ opentelemetry-api = ">=1"
 protobuf = ">=3"
 setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 six = ">=1.12.0"
+sqlparse = ">=0.2.2"
 typing-extensions = "*"
 xmltodict = ">=0.12"
 
@@ -496,6 +444,18 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
@@ -520,35 +480,15 @@ files = [
 ]
 
 [[package]]
-name = "nose2"
-version = "0.9.2"
-description = "unittest2 with plugins, the succesor to nose"
-category = "main"
-optional = true
-python-versions = "*"
-files = [
-    {file = "nose2-0.9.2-py2.py3-none-any.whl", hash = "sha256:fd4b84c65ecea869080a23bdb8916716f5363df3b899933991c861ada8aa3f48"},
-    {file = "nose2-0.9.2.tar.gz", hash = "sha256:8762f77925bbafcdf38331e0e2ee718756fb75ff74b1f9097cd08731ad59ab5e"},
-]
-
-[package.dependencies]
-coverage = ">=4.4.1"
-six = ">=1.7"
-
-[package.extras]
-coverage-plugin = ["coverage (>=4.4.1)"]
-doc = ["Sphinx (>=1.6.5)", "mock", "sphinx-rtd-theme"]
-
-[[package]]
 name = "opentelemetry-api"
-version = "1.22.0"
+version = "1.23.0"
 description = "OpenTelemetry Python API"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "opentelemetry_api-1.22.0-py3-none-any.whl", hash = "sha256:43621514301a7e9f5d06dd8013a1b450f30c2e9372b8e30aaeb4562abf2ce034"},
-    {file = "opentelemetry_api-1.22.0.tar.gz", hash = "sha256:15ae4ca925ecf9cfdfb7a709250846fbb08072260fca08ade78056c502b86bed"},
+    {file = "opentelemetry_api-1.23.0-py3-none-any.whl", hash = "sha256:cc03ea4025353048aadb9c64919099663664672ea1c6be6ddd8fee8e4cd5e774"},
+    {file = "opentelemetry_api-1.23.0.tar.gz", hash = "sha256:14a766548c8dd2eb4dfc349739eb4c3893712a0daa996e5dbf945f9da665da9d"},
 ]
 
 [package.dependencies]
@@ -556,24 +496,52 @@ deprecated = ">=1.2.6"
 importlib-metadata = ">=6.0,<7.0"
 
 [[package]]
+name = "packaging"
+version = "24.0"
+description = "Core utilities for Python packages"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.4.0"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
+    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "protobuf"
-version = "4.25.2"
+version = "4.25.3"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "protobuf-4.25.2-cp310-abi3-win32.whl", hash = "sha256:b50c949608682b12efb0b2717f53256f03636af5f60ac0c1d900df6213910fd6"},
-    {file = "protobuf-4.25.2-cp310-abi3-win_amd64.whl", hash = "sha256:8f62574857ee1de9f770baf04dde4165e30b15ad97ba03ceac65f760ff018ac9"},
-    {file = "protobuf-4.25.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:2db9f8fa64fbdcdc93767d3cf81e0f2aef176284071507e3ede160811502fd3d"},
-    {file = "protobuf-4.25.2-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:10894a2885b7175d3984f2be8d9850712c57d5e7587a2410720af8be56cdaf62"},
-    {file = "protobuf-4.25.2-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:fc381d1dd0516343f1440019cedf08a7405f791cd49eef4ae1ea06520bc1c020"},
-    {file = "protobuf-4.25.2-cp38-cp38-win32.whl", hash = "sha256:33a1aeef4b1927431d1be780e87b641e322b88d654203a9e9d93f218ee359e61"},
-    {file = "protobuf-4.25.2-cp38-cp38-win_amd64.whl", hash = "sha256:47f3de503fe7c1245f6f03bea7e8d3ec11c6c4a2ea9ef910e3221c8a15516d62"},
-    {file = "protobuf-4.25.2-cp39-cp39-win32.whl", hash = "sha256:5e5c933b4c30a988b52e0b7c02641760a5ba046edc5e43d3b94a74c9fc57c1b3"},
-    {file = "protobuf-4.25.2-cp39-cp39-win_amd64.whl", hash = "sha256:d66a769b8d687df9024f2985d5137a337f957a0916cf5464d1513eee96a63ff0"},
-    {file = "protobuf-4.25.2-py3-none-any.whl", hash = "sha256:a8b7a98d4ce823303145bf3c1a8bdb0f2f4642a414b196f04ad9853ed0c8f830"},
-    {file = "protobuf-4.25.2.tar.gz", hash = "sha256:fe599e175cb347efc8ee524bcd4b902d11f7262c0e569ececcb89995c15f0a5e"},
+    {file = "protobuf-4.25.3-cp310-abi3-win32.whl", hash = "sha256:d4198877797a83cbfe9bffa3803602bbe1625dc30d8a097365dbc762e5790faa"},
+    {file = "protobuf-4.25.3-cp310-abi3-win_amd64.whl", hash = "sha256:209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8"},
+    {file = "protobuf-4.25.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d"},
+    {file = "protobuf-4.25.3-cp38-cp38-win32.whl", hash = "sha256:f4f118245c4a087776e0a8408be33cf09f6c547442c00395fbfb116fac2f8ac2"},
+    {file = "protobuf-4.25.3-cp38-cp38-win_amd64.whl", hash = "sha256:c053062984e61144385022e53678fbded7aea14ebb3e0305ae3592fb219ccfa4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win32.whl", hash = "sha256:19b270aeaa0099f16d3ca02628546b8baefe2955bbe23224aaf856134eccf1e4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win_amd64.whl", hash = "sha256:e3c97a1555fd6388f857770ff8b9703083de6bf1f9274a002a332d65fbb56c8c"},
+    {file = "protobuf-4.25.3-py3-none-any.whl", hash = "sha256:f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9"},
+    {file = "protobuf-4.25.3.tar.gz", hash = "sha256:25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c"},
 ]
 
 [[package]]
@@ -601,15 +569,38 @@ files = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.1.1"
+description = "pytest: simple powerful testing with Python"
+category = "main"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.4,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 category = "main"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -657,20 +648,20 @@ crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "setuptools"
-version = "69.0.3"
+version = "69.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
+    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -685,15 +676,44 @@ files = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.4.4"
+description = "A non-validating SQL parser."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "sqlparse-0.4.4-py3-none-any.whl", hash = "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3"},
+    {file = "sqlparse-0.4.4.tar.gz", hash = "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"},
+]
+
+[package.extras]
+dev = ["build", "flake8"]
+doc = ["sphinx"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
+    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
 ]
 
 [[package]]
@@ -840,9 +860,9 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
-dev = ["boto3", "flake8", "nose2", "requests"]
+dev = ["boto3", "flake8", "pytest", "requests"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<4"
-content-hash = "0025ef8e84fb9e0a746e623853293967663e40854dafb3689ca14da2eb228b84"
+content-hash = "80b471e42622e7de85a0795ad15cb6c01e61dd65df354b5e289a2cd47536a26b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 python = ">=3.8.0,<4"
 datadog = ">=0.41.0,<1.0.0"
 wrapt = "^1.11.2"
-ddtrace = ">=2.5.1"
+ddtrace = ">=2.7.2"
 urllib3 = [
     {version = "<2.0.0", python = "<3.11", optional = true},
     {version = "<2.1.0", python = ">=3.11", optional = true},

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -56,6 +56,11 @@ if [ -z "$DD_API_KEY" ]; then
     exit 1
 fi
 
+if [ -z "$ARCH" ]; then
+    echo "No ARCH env var set, exiting"
+    exit 1
+fi
+
 if [ -n "$UPDATE_SNAPSHOTS" ]; then
     echo "Overwriting snapshots in this execution"
 fi


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- Bumps ddtrace
- Fixes a devex hiccup where the integration test now requires an ARCH env var.

### Motivation
always be shipping

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
