### PR TITLE
Properly parent lazily loaded module imports.

### DIFF
--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 _cold_start = True
 _proactive_initialization = False
 _lambda_container_initialized = False
+_tracer = None
 
 
 def set_cold_start(init_timestamp_ns):
@@ -18,6 +19,7 @@ def set_cold_start(init_timestamp_ns):
     global _cold_start
     global _lambda_container_initialized
     global _proactive_initialization
+    global _tracer
     if not _lambda_container_initialized:
         now = time.time_ns()
         if (now - init_timestamp_ns) // 1_000_000_000 > 10:
@@ -29,6 +31,7 @@ def set_cold_start(init_timestamp_ns):
         _cold_start = False
         _proactive_initialization = False
     _lambda_container_initialized = True
+    from ddtrace import tracer as _tracer
 
 
 def is_cold_start():
@@ -62,6 +65,9 @@ class ImportNode(object):
         self.start_time_ns = start_time_ns
         self.end_time_ns = end_time_ns
         self.children = []
+        self.context = None
+        if _lambda_container_initialized:
+            self.context = _tracer.context_provider.active()
 
 
 root_nodes: List[ImportNode] = []
@@ -183,7 +189,8 @@ class ColdStartTracer(object):
         cold_start_span = self.create_cold_start_span(cold_start_span_start_time_ns)
         while root_nodes:
             root_node = root_nodes.pop()
-            self.trace_tree(root_node, cold_start_span)
+            parent = root_node.context or cold_start_span
+            self.trace_tree(root_node, parent)
         self.finish_span(cold_start_span, cold_start_span_end_time_ns)
 
     def trace_tree(self, import_node: ImportNode, parent_span):

--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -76,10 +76,8 @@ already_wrapped_loaders = set()
 
 
 def reset_node_stacks():
-    global root_nodes
-    root_nodes = []
-    global import_stack
-    import_stack = []
+    root_nodes.clear()
+    import_stack.clear()
 
 
 def push_node(module_name, file_path):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Properly parent `aws.lambda.import` spans for packages that are imported during function execution. Currently app spans are children of the cold start span, which is incorrect.

<img width="1349" alt="Screenshot 2024-03-06 at 1 01 36 PM" src="https://github.com/DataDog/datadog-lambda-python/assets/1383216/c1d35776-439e-42d9-af00-a6c9f65f2da9">

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
