### PR TITLE
Replace string formatting with f strings.

### DIFF
--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -50,14 +50,14 @@ def is_new_sandbox():
 
 def get_cold_start_tag():
     """Returns the cold start tag to be used in metrics"""
-    return "cold_start:true" if is_cold_start() else "cold_start:false"
+    return "cold_start:true" if _cold_start else "cold_start:false"
 
 
 def get_proactive_init_tag():
     """Returns the proactive init tag to be used in metrics"""
     return (
         "proactive_initialization:true"
-        if is_proactive_init()
+        if _proactive_initialization
         else "proactive_initialization:false"
     )
 

--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -50,12 +50,16 @@ def is_new_sandbox():
 
 def get_cold_start_tag():
     """Returns the cold start tag to be used in metrics"""
-    return "cold_start:{}".format(str(is_cold_start()).lower())
+    return "cold_start:true" if is_cold_start() else "cold_start:false"
 
 
 def get_proactive_init_tag():
     """Returns the proactive init tag to be used in metrics"""
-    return "proactive_initialization:{}".format(str(is_proactive_init()).lower())
+    return (
+        "proactive_initialization:true"
+        if is_proactive_init()
+        else "proactive_initialization:false"
+    )
 
 
 class ImportNode(object):

--- a/datadog_lambda/handler.py
+++ b/datadog_lambda/handler.py
@@ -22,7 +22,7 @@ if path is None:
     )
 parts = path.rsplit(".", 1)
 if len(parts) != 2:
-    raise HandlerError("Value %s for DD_LAMBDA_HANDLER has invalid format." % path)
+    raise HandlerError(f"Value {path} for DD_LAMBDA_HANDLER has invalid format.")
 
 
 (mod_name, handler_name) = parts

--- a/datadog_lambda/tag_object.py
+++ b/datadog_lambda/tag_object.py
@@ -30,17 +30,17 @@ def tag_object(span, key, obj, depth=0):
         return span.set_tag(key, str(obj))
     if isinstance(obj, list):
         for k, v in enumerate(obj):
-            formatted_key = "{}.{}".format(key, k)
+            formatted_key = f"{key}.{k}"
             tag_object(span, formatted_key, v, depth)
         return
     if hasattr(obj, "items"):
         for k, v in obj.items():
-            formatted_key = "{}.{}".format(key, k)
+            formatted_key = f"{key}.{k}"
             tag_object(span, formatted_key, v, depth)
         return
     if hasattr(obj, "to_dict"):
         for k, v in obj.to_dict().items():
-            formatted_key = "{}.{}".format(key, k)
+            formatted_key = f"{key}.{k}"
             tag_object(span, formatted_key, v, depth)
         return
     try:

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -734,7 +734,7 @@ def create_inferred_span_from_lambda_function_url_event(event, context):
     service_name = determine_service_name(service_mapping, api_id, "lambda_url", domain)
     method = request_context.get("http", {}).get("method")
     path = request_context.get("http", {}).get("path")
-    resource = "{0} {1}".format(method, path)
+    resource = f"{method} {path}"
     tags = {
         "operation_name": "aws.lambda.url",
         "http.url": domain + path,
@@ -894,7 +894,7 @@ def create_inferred_span_from_api_gateway_event(
     method = event.get("httpMethod")
     path = event.get("path")
     resource_path = _get_resource_path(event, request_context)
-    resource = "{0} {1}".format(method, resource_path)
+    resource = f"{method} {resource_path}"
     tags = {
         "operation_name": "aws.apigateway.rest",
         "http.url": domain + path,
@@ -959,7 +959,7 @@ def create_inferred_span_from_http_api_event(
     method = request_context.get("http", {}).get("method")
     path = event.get("rawPath")
     resource_path = _get_resource_path(event, request_context)
-    resource = "{0} {1}".format(method, resource_path)
+    resource = f"{method} {resource_path}"
     tags = {
         "operation_name": "aws.httpapi",
         "endpoint": path,

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -204,9 +204,7 @@ def parse_event_source_arn(source: _EventSource, event: dict, context: Any) -> s
         distribution_id = (
             event_record.get("cf", {}).get("config", {}).get("distributionId")
         )
-        return "arn:{}:cloudfront::{}:distribution/{}".format(
-            aws_arn, account_id, distribution_id
-        )
+        return f"arn:{aws_arn}:cloudfront::{account_id}:distribution/{distribution_id}"
 
     # e.g. arn:aws:lambda:<region>:<account_id>:url:<function-name>:<function-qualifier>
     if source.equals(EventTypes.LAMBDA_FUNCTION_URL):
@@ -223,9 +221,9 @@ def parse_event_source_arn(source: _EventSource, event: dict, context: Any) -> s
     # e.g. arn:aws:apigateway:us-east-1::/restapis/xyz123/stages/default
     if source.event_type == EventTypes.API_GATEWAY:
         request_context = event.get("requestContext")
-        return "arn:{}:apigateway:{}::/restapis/{}/stages/{}".format(
-            aws_arn, region, request_context.get("apiId"), request_context.get("stage")
-        )
+        api_id = request_context.get("apiId")
+        stage = request_context.get("stage")
+        return f"arn:{aws_arn}:apigateway:{region}::/restapis/{api_id}/stages/{stage}"
 
     # e.g. arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/lambda-xyz/123
     if source.event_type == EventTypes.ALB:
@@ -240,9 +238,7 @@ def parse_event_source_arn(source: _EventSource, event: dict, context: Any) -> s
             data = b"".join(BufferedReader(decompress_stream))
         logs = json.loads(data)
         log_group = logs.get("logGroup", "cloudwatch")
-        return "arn:{}:logs:{}:{}:log-group:{}".format(
-            aws_arn, region, account_id, log_group
-        )
+        return f"arn:{aws_arn}:logs:{region}:{account_id}:log-group:{log_group}"
 
     # e.g. arn:aws:events:us-east-1:123456789012:rule/my-schedule
     if source.event_type == EventTypes.CLOUDWATCH_EVENTS and event.get("resources"):

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -381,9 +381,8 @@ class _LambdaDecorator(object):
 
 
 def format_err_with_traceback(e):
-    return "Error {}. Traceback: {}".format(
-        e, traceback.format_exc().replace("\n", "\r")
-    )
+    tb = traceback.format_exc().replace("\n", "\r")
+    return f"Error {e}. Traceback: {tb}"
 
 
 datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -41,7 +41,7 @@ def send(host_port_tuple, payload):
 def build_segment_payload(payload):
     if payload is None:
         return None
-    return '{"format": "json", "version": 1}' + "\n" + payload
+    return '{"format": "json", "version": 1}\n' + payload
 
 
 def parse_xray_header(raw_trace_id):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -18,7 +18,7 @@ def get_mock_context(
 
 class TestMetricTags(unittest.TestCase):
     def setUp(self):
-        patcher = patch("datadog_lambda.tags.python_version_tuple")
+        patcher = patch("sys.version_info", (3, 12, 0))
         self.mock_python_version_tuple = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -65,5 +65,4 @@ class TestMetricTags(unittest.TestCase):
         )
 
     def test_get_runtime_tag(self):
-        self.mock_python_version_tuple.return_value = ("3", "12", "0")
         self.assertEqual(get_runtime_tag(), "runtime:python3.12")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -66,9 +66,8 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_is_cold_start.return_value = True
         self.addCleanup(patcher.stop)
 
-        patcher = patch("datadog_lambda.tags.python_version_tuple")
+        patcher = patch("sys.version_info", (3, 9, 10))
         self.mock_python_version_tuple = patcher.start()
-        self.mock_python_version_tuple.return_value = ("3", "9", "10")
         self.addCleanup(patcher.stop)
 
         patcher = patch("datadog_lambda.metric.write_metric_point_to_stdout")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -61,9 +61,9 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_patch_all = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch("datadog_lambda.cold_start.is_cold_start")
-        self.mock_is_cold_start = patcher.start()
-        self.mock_is_cold_start.return_value = True
+        patcher = patch("datadog_lambda.tags.get_cold_start_tag")
+        self.mock_get_cold_start_tag = patcher.start()
+        self.mock_get_cold_start_tag.return_value = "cold_start:true"
         self.addCleanup(patcher.stop)
 
         patcher = patch("sys.version_info", (3, 9, 10))
@@ -353,7 +353,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
 
         lambda_handler(lambda_event, get_mock_context())
 
-        self.mock_is_cold_start.return_value = False
+        self.mock_get_cold_start_tag.return_value = "cold_start:false"
 
         lambda_handler(
             lambda_event, get_mock_context(aws_request_id="second-request-id")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Replaces string formatting `"my {}".format("string")` with f strings `f"my {'string'}"`.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
