### PR TITLE
Small performance improvements to %s formatted strings.

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -529,8 +529,8 @@ def get_dd_trace_context_obj():
         xray_context = _get_xray_trace_context()  # xray (sub)segment
     except Exception as e:
         logger.debug(
-            "get_dd_trace_context couldn't read from segment from x-ray, with error %s"
-            % e
+            "get_dd_trace_context couldn't read from segment from x-ray, with error %s",
+            e
         )
     if not xray_context:
         return None
@@ -1051,7 +1051,7 @@ def create_inferred_span_from_sqs_event(event, context):
 
         except Exception as e:
             logger.debug(
-                "Unable to create upstream span from SQS message, with error %s" % e
+                "Unable to create upstream span from SQS message, with error %s", e
             )
             pass
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -530,7 +530,7 @@ def get_dd_trace_context_obj():
     except Exception as e:
         logger.debug(
             "get_dd_trace_context couldn't read from segment from x-ray, with error %s",
-            e
+            e,
         )
     if not xray_context:
         return None

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -31,11 +31,11 @@ def send(host_port_tuple, payload):
         sock.connect(host_port_tuple)
         sock.send(payload.encode("utf-8"))
     except Exception as e_send:
-        logger.error("Error occurred submitting to xray daemon: %s", str(e_send))
+        logger.error("Error occurred submitting to xray daemon: %s", e_send)
     try:
         sock.close()
     except Exception as e_close:
-        logger.error("Error while closing the socket: %s", str(e_close))
+        logger.error("Error while closing the socket: %s", e_close)
 
 
 def build_segment_payload(payload):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Replace all uses of `%` string interpolation.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

```
$ python -m timeit -s 'import logging ; logger = logging.getLogger(__name__) ; world = "world"' 'logger.debug("hello %s", world)'
5000000 loops, best of 5: 78 nsec per loop
$ python -m timeit -s 'import logging ; logger = logging.getLogger(__name__) ; world = "world"' 'logger.debug(f"hello {world}")'
5000000 loops, best of 5: 97.8 nsec per loop
```

If the log level is set higher than the log message being produced, it is actually faster to use a `%s` type string than an f string.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
