### PR TITLE
Do not recalculate enhanced metric setting each time.

### DIFF
--- a/datadog_lambda/extension.py
+++ b/datadog_lambda/extension.py
@@ -1,5 +1,5 @@
 import logging
-from os import path
+import os
 
 AGENT_URL = "http://127.0.0.1:8124"
 FLUSH_PATH = "/lambda/flush"
@@ -9,9 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_extension_present():
-    if path.exists(EXTENSION_PATH):
-        return True
-    return False
+    return os.path.exists(EXTENSION_PATH)
 
 
 def flush_extension():

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -32,6 +32,10 @@ else:
     flush_in_thread = os.environ.get("DD_FLUSH_IN_THREAD", "").lower() == "true"
     lambda_stats = ThreadStatsWriter(flush_in_thread)
 
+enhanced_metrics_enabled = (
+    os.environ.get("DD_ENHANCED_METRICS", "true").lower() == "true"
+)
+
 
 def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=False):
     """
@@ -89,16 +93,6 @@ def flush_stats():
     lambda_stats.flush()
 
 
-def are_enhanced_metrics_enabled():
-    """Check env var to find if enhanced metrics should be submitted
-
-    Returns:
-        boolean for whether enhanced metrics are enabled
-    """
-    # DD_ENHANCED_METRICS defaults to true
-    return os.environ.get("DD_ENHANCED_METRICS", "true").lower() == "true"
-
-
 def submit_enhanced_metric(metric_name, lambda_context):
     """Submits the enhanced metric with the given name
 
@@ -106,7 +100,7 @@ def submit_enhanced_metric(metric_name, lambda_context):
         metric_name (str): metric name w/o enhanced prefix i.e. "invocations" or "errors"
         lambda_context (dict): Lambda context dict passed to the function by AWS
     """
-    if not are_enhanced_metrics_enabled():
+    if not enhanced_metrics_enabled:
         logger.debug(
             "Not submitting enhanced metric %s because enhanced metrics are disabled",
             metric_name,

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -465,7 +465,9 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         )
 
     def test_no_enhanced_metrics_without_env_var(self):
-        os.environ["DD_ENHANCED_METRICS"] = "false"
+        patcher = patch("datadog_lambda.metric.enhanced_metrics_enabled", False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
         @wrapper.datadog_lambda_wrapper
         def lambda_handler(event, context):
@@ -477,8 +479,6 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             lambda_handler(lambda_event, get_mock_context())
 
         self.mock_write_metric_point_to_stdout.assert_not_called()
-
-        del os.environ["DD_ENHANCED_METRICS"]
 
     def test_only_one_wrapper_in_use(self):
         patcher = patch("datadog_lambda.wrapper.submit_invocations_metric")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Sets the value for enhanced metrics as a global instead of recalculating it each time.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
