### PR TITLE
Benchmarks for operations that use json dump/load.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ pip-log.txt
 
 node_modules
 yarn-lock.json
+
+.benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ boto3 = { version = "^1.28.0", optional = true }
 typing_extensions = {version = "^4.0", python = "<3.8"}
 requests = { version ="^2.22.0", optional = true }
 pytest = { version= "^8.0.0", optional = true }
+pytest-benchmark = { version = "^4.0", optional = true }
 flake8 = { version = "^5.0.4", optional = true }
 
 
@@ -45,9 +46,13 @@ dev = [
     "boto3",
     "flake8",
     "pytest",
+    "pytest-benchmark",
     "requests",
 ]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-disable --benchmark-autosave"

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -11,6 +11,8 @@ from datadog_lambda import tracing
 from datadog_lambda import trigger
 from datadog_lambda import xray
 
+from datadog_lambda.constants import XrayDaemon, XraySubsegment
+
 from tests.utils import get_mock_context
 
 
@@ -71,10 +73,15 @@ def test_trigger_extract_trigger_tags(event, benchmark):
     benchmark(trigger.extract_trigger_tags, event, context)
 
 
-def test_xray_send_segment(benchmark):
+def test_xray_send_segment(benchmark, monkeypatch):
+    monkeypatch.setenv(XrayDaemon.XRAY_DAEMON_ADDRESS, "localhost:9000")
+    monkeypatch.setenv(
+        XrayDaemon.XRAY_TRACE_ID_HEADER_NAME,
+        "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0",
+    )
     key = {
         "trace-id": "12345678901234567890123456789012",
         "parent-id": "1234567890123456",
         "sampling-priority": "1",
     }
-    benchmark(xray.send_segment, key, "trace")
+    benchmark(xray.send_segment, XraySubsegment.TRACE_KEY, key)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,80 @@
+import builtins
+import json
+import os
+import pytest
+
+import ddtrace
+
+from datadog_lambda import metric
+from datadog_lambda import tag_object
+from datadog_lambda import tracing
+from datadog_lambda import trigger
+from datadog_lambda import xray
+
+from tests.utils import get_mock_context
+
+
+event_samples_dir = "tests/event_samples"
+event_samples = [f[:-5] for f in os.listdir(event_samples_dir) if f.endswith(".json")]
+
+
+def test_metric_write_metric_point_to_stdout(benchmark, monkeypatch):
+    monkeypatch.setattr(builtins, "print", lambda *a, **k: None)
+    benchmark(
+        metric.write_metric_point_to_stdout,
+        "metric_name",
+        1,
+        tags=[
+            "tag1:value1",
+            "tag2:value2",
+            "tag3:value3",
+        ],
+    )
+
+
+@pytest.mark.parametrize("event", event_samples)
+def test_tag_object_tag_object(event, benchmark):
+    with open(f"{event_samples_dir}/{event}.json") as f:
+        event = json.load(f)
+    span = ddtrace.tracer.start_span("test")
+    benchmark(tag_object.tag_object, span, "function.request", event)
+
+
+@pytest.mark.parametrize("event", event_samples)
+def test_tracing_create_inferred_span(event, benchmark):
+    with open(f"{event_samples_dir}/{event}.json") as f:
+        event = json.load(f)
+    context = get_mock_context()
+    benchmark(tracing.create_inferred_span, event, context)
+
+
+@pytest.mark.parametrize("event", event_samples)
+def test_tracing_extract_dd_trace_context(event, benchmark):
+    with open(f"{event_samples_dir}/{event}.json") as f:
+        event = json.load(f)
+    context = get_mock_context()
+    benchmark(tracing.extract_dd_trace_context, event, context)
+
+
+@pytest.mark.parametrize("event", event_samples)
+def test_trigger_parse_event_source(event, benchmark):
+    with open(f"{event_samples_dir}/{event}.json") as f:
+        event = json.load(f)
+    benchmark(trigger.parse_event_source, event)
+
+
+@pytest.mark.parametrize("event", event_samples)
+def test_trigger_extract_trigger_tags(event, benchmark):
+    with open(f"{event_samples_dir}/{event}.json") as f:
+        event = json.load(f)
+    context = get_mock_context()
+    benchmark(trigger.extract_trigger_tags, event, context)
+
+
+def test_xray_send_segment(benchmark):
+    key = {
+        "trace-id": "12345678901234567890123456789012",
+        "parent-id": "1234567890123456",
+        "sampling-priority": "1",
+    }
+    benchmark(xray.send_segment, key, "trace")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Adds benchmarks using the `pytest-benchmark` plugin. Benchmarks added cover all uses of json dump/load.

### Motivation

<!--- What inspired you to submit this pull request? --->

I wanted a tool to help me see how much impact a perf update makes.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
