### PR TITLE
Use single socket instance for all xray api calls.

### DIFF
--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -30,13 +30,6 @@ class Socket(object):
         except Exception as e_send:
             logger.error("Error occurred submitting to xray daemon: %s", e_send)
 
-    def reset(self):
-        if hasattr(self, "_host_port_tuple"):
-            del self._host_port_tuple
-        if self.sock:
-            self.sock.close()
-            self.sock = None
-
     def _connect(self):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setblocking(0)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -13,7 +13,7 @@ from datadog_lambda import xray
 
 from datadog_lambda.constants import XrayDaemon, XraySubsegment
 
-from tests.utils import get_mock_context
+from tests.utils import get_mock_context, reset_xray_connection
 
 
 event_samples_dir = "tests/event_samples"
@@ -74,7 +74,7 @@ def test_trigger_extract_trigger_tags(event, benchmark):
 
 
 def test_xray_send_segment(benchmark, monkeypatch):
-    xray.sock.reset()
+    reset_xray_connection()
 
     monkeypatch.setenv(XrayDaemon.XRAY_DAEMON_ADDRESS, "localhost:9000")
     monkeypatch.setenv(

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -74,14 +74,24 @@ def test_trigger_extract_trigger_tags(event, benchmark):
 
 
 def test_xray_send_segment(benchmark, monkeypatch):
+    xray.sock.reset()
+
     monkeypatch.setenv(XrayDaemon.XRAY_DAEMON_ADDRESS, "localhost:9000")
     monkeypatch.setenv(
         XrayDaemon.XRAY_TRACE_ID_HEADER_NAME,
         "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0",
     )
+
+    def socket_send(*a, **k):
+        sends.append(True)
+
+    sends = []
+    monkeypatch.setattr("socket.socket.send", socket_send)
+
     key = {
         "trace-id": "12345678901234567890123456789012",
         "parent-id": "1234567890123456",
         "sampling-priority": "1",
     }
     benchmark(xray.send_segment, XraySubsegment.TRACE_KEY, key)
+    assert sends

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, call, ANY
 from datadog_lambda.constants import TraceHeader
 
 import datadog_lambda.wrapper as wrapper
+import datadog_lambda.xray as xray
 from datadog_lambda.metric import lambda_metric
 from datadog_lambda.thread_stats_writer import ThreadStatsWriter
 from ddtrace import Span, tracer
@@ -590,7 +591,9 @@ class TestLambdaWrapperWithTraceContext(unittest.TestCase):
         },
     )
     def test_event_bridge_sqs_payload(self):
-        patcher = patch("datadog_lambda.xray.send")
+        xray.sock.reset()
+
+        patcher = patch("datadog_lambda.xray.sock.send")
         mock_send = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -623,7 +626,7 @@ class TestLambdaWrapperWithTraceContext(unittest.TestCase):
         self.assertEqual(result.span_id, aws_lambda_span.span_id)
         self.assertEqual(result.sampling_priority, 1)
         mock_send.assert_called_once()
-        (_, raw_payload), _ = mock_send.call_args
+        (raw_payload,), _ = mock_send.call_args
         payload = json.loads(raw_payload[33:])  # strip formatting prefix
         self.assertEqual(self.xray_root, payload["trace_id"])
         self.assertEqual(self.xray_parent, payload["parent_id"])

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -13,7 +13,7 @@ from datadog_lambda.thread_stats_writer import ThreadStatsWriter
 from ddtrace import Span, tracer
 from ddtrace.internal.constants import MAX_UINT_64BITS
 
-from tests.utils import get_mock_context
+from tests.utils import get_mock_context, reset_xray_connection
 
 
 class TestDatadogLambdaWrapper(unittest.TestCase):
@@ -591,7 +591,7 @@ class TestLambdaWrapperWithTraceContext(unittest.TestCase):
         },
     )
     def test_event_bridge_sqs_payload(self):
-        xray.sock.reset()
+        reset_xray_connection()
 
         patcher = patch("datadog_lambda.xray.sock.send")
         mock_send = patcher.start()

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -5,11 +5,12 @@ import os
 from unittest.mock import MagicMock, patch
 
 from datadog_lambda.xray import build_segment_payload, build_segment, send_segment, sock
+from tests.utils import reset_xray_connection
 
 
 class TestXRay(unittest.TestCase):
     def setUp(self):
-        sock.reset()
+        reset_xray_connection()
 
     def tearDown(self):
         if os.environ.get("_X_AMZN_TRACE_ID"):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,3 +24,13 @@ def get_mock_context(
     lambda_context.function_name = function_name
     lambda_context.client_context = ClientContext(custom)
     return lambda_context
+
+
+def reset_xray_connection():
+    from datadog_lambda.xray import sock
+
+    if hasattr(sock, "_host_port_tuple"):
+        del sock._host_port_tuple
+    if sock.sock:
+        sock.sock.close()
+        sock.sock = None


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

+ Use single socket connection for all interactions with the xray api
+ Memoize xray api host/port identification
+ Ensure socket creation is done as lazily as possible

### Motivation

<!--- What inspired you to submit this pull request? --->

The need for speed.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Previously, we were creating a new socket connection and closing the connection for each xray api call. When xray is enabled, and the lambda has extracted trace context from an upstream event, the xray api is called twice.

When an xray api is called, this change decreases runtime duration by somewhere between 1-5%.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
