### PR TITLE
Delay import of logging initialization code.

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
 __version__ = importlib_metadata.version(__name__)
 
 
-from datadog_lambda.logger import initialize_logging
+from datadog_lambda.logger import initialize_logging  # noqa: E402
 
 
 initialize_logging(__name__)

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,5 +1,4 @@
 from datadog_lambda.cold_start import initialize_cold_start_tracing
-from datadog_lambda.logger import initialize_logging
 import os
 
 
@@ -19,5 +18,9 @@ except ModuleNotFoundError:
     import importlib_metadata
 
 __version__ = importlib_metadata.version(__name__)
+
+
+from datadog_lambda.logger import initialize_logging
+
 
 initialize_logging(__name__)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Move the import of `initialize_logging` to after cold start has been initialized.

### Motivation

<!--- What inspired you to submit this pull request? --->

This allows us to also be able to trace the import of the builtin `logging` package.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
