### PR TITLE
Replace builtin json with faster ujson package.

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,9 +3,11 @@ datadog,github.com/DataDog/datadogpy,BSD-3-Clause,"Copyright (c) 2015-Present Da
 wrapt,github.com/GrahamDumpleton/wrapt,BSD-2-Clause,"Copyright (c) 2013-2019, Graham Dumpleton"
 ddtrace,github.com/DataDog/dd-trace-py,BSD-3-Clause,"Copyright (c) 2016, Datadog <info@datadoghq.com>"
 urllib3,github.com/urllib3/urllib3,MIT,Copyright (c) 2008-2020 Andrey Petrov and contributors.
+ujson,github.com/ultrajson/ultrajson,BSD-3-Clause,"Copyright (c) 2014, Electronic Arts Inc"
 importlib_metadata,github.com/python/importlib_metadata,Apache-2.0,Copyright © Jason R. Coombs
 boto3,github.com/boto/boto3,Apache-2.0,"Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved."
 typing_extensions,github.com/python/typing_extensions,PSF-2.0,"Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The Netherlands. All rights reserved"
 requests,github.com/psf/requests,Apache-2.0,"Copyright 2018 Kenneth Reitz"
 pytest,github.com/pytest-dev/pytest,MIT,Copyright (c) 2004 Holger Krekel and others
+pytest-benchmark,github.com/ionelmc/pytest-benchmark,BSD-2-Clause,"Copyright (c) 2014-2023, Ionel Cristian Mărieș. All rights reserved."
 flake8,gitlab.com/pycqa/flake8,MIT,"Copyright (C) 2011-2013 Tarek Ziade <tarek@ziade.org>. Copyright (C) 2012-2016 Ian Cordasco <graffatcolmingov@gmail.com>."

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -4,9 +4,9 @@
 # Copyright 2019 Datadog, Inc.
 
 import os
-import json
 import time
 import logging
+import ujson as json
 
 from datadog_lambda.extension import should_use_extension
 from datadog_lambda.tags import get_enhanced_metrics_tags, dd_lambda_layer_tag

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -85,7 +85,8 @@ def write_metric_point_to_stdout(metric_name, value, timestamp=None, tags=[]):
                 "v": value,
                 "e": timestamp or int(time.time()),
                 "t": tags,
-            }
+            },
+            escape_forward_slashes=False,
         )
     )
 

--- a/datadog_lambda/patch.py
+++ b/datadog_lambda/patch.py
@@ -3,11 +3,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-import json
 import os
 import sys
 import logging
 import zlib
+import ujson as json
 
 from wrapt import wrap_function_wrapper as wrap
 from wrapt.importer import when_imported

--- a/datadog_lambda/patch.py
+++ b/datadog_lambda/patch.py
@@ -144,14 +144,14 @@ def _print_request_string(request):
         data = zlib.decompress(data)
     data_dict = json.loads(data)
     data_dict.get("series", []).sort(key=lambda series: series.get("metric"))
-    sorted_data = json.dumps(data_dict)
+    sorted_data = json.dumps(data_dict, escape_forward_slashes=False)
 
     # Sort headers to prevent any differences in ordering
     headers = request.headers or {}
     sorted_headers = sorted(
         "{}:{}".format(key, value) for key, value in headers.items()
     )
-    sorted_header_str = json.dumps(sorted_headers)
+    sorted_header_str = json.dumps(sorted_headers, escape_forward_slashes=False)
     print(
         "HTTP {} {} Headers: {} Data: {}".format(
             method, url, sorted_header_str, sorted_data

--- a/datadog_lambda/tag_object.py
+++ b/datadog_lambda/tag_object.py
@@ -4,8 +4,8 @@
 # Copyright 2021 Datadog, Inc.
 
 from decimal import Decimal
-import json
 import logging
+import ujson as json
 
 redactable_keys = ["authorization", "x-authorization", "password", "token"]
 max_depth = 10

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -5,8 +5,8 @@
 import hashlib
 import logging
 import os
-import json
 import base64
+import ujson as json
 from datetime import datetime, timezone
 from typing import Optional, Dict
 

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -5,7 +5,7 @@
 
 import base64
 import gzip
-import json
+import ujson as json
 from io import BytesIO, BufferedReader
 from enum import Enum
 from typing import Any

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -258,7 +258,9 @@ class _LambdaDecorator(object):
         injected_headers[Headers.Parent_Span_Finish_Time] = finish_time_ns
         if request_id is not None:
             injected_headers[Headers.Authorizing_Request_Id] = request_id
-        datadog_data = base64.b64encode(json.dumps(injected_headers).encode()).decode()
+        datadog_data = base64.b64encode(
+            json.dumps(injected_headers, escape_forward_slashes=False).encode()
+        ).decode()
         self.response.setdefault("context", {})
         self.response["context"]["_datadog"] = datadog_data
 

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -6,8 +6,8 @@ import base64
 import os
 import logging
 import traceback
+import ujson as json
 from importlib import import_module
-import json
 from time import time_ns
 
 from datadog_lambda.extension import should_use_extension, flush_extension

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -1,9 +1,9 @@
 import os
 import logging
-import json
 import binascii
 import time
 import socket
+import ujson as json
 
 from datadog_lambda.constants import XrayDaemon, XraySubsegment, TraceContextSource
 

--- a/datadog_lambda/xray.py
+++ b/datadog_lambda/xray.py
@@ -102,7 +102,8 @@ def build_segment(context, key, metadata):
                     key: metadata,
                 }
             },
-        }
+        },
+        escape_forward_slashes=False,
     )
     return segment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python = ">=3.8.0,<4"
 datadog = ">=0.41.0,<1.0.0"
 wrapt = "^1.11.2"
 ddtrace = ">=2.7.2"
+ujson = ">=5.9.0"
 urllib3 = [
     {version = "<2.0.0", python = "<3.11", optional = true},
     {version = "<2.1.0", python = ">=3.11", optional = true},


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Replaces instances of the builtin `json` package to use `ujson` instead.

### Motivation

<!--- What inspired you to submit this pull request? --->

The builtin `json` package is pretty slow for loading/dumping data. There are faster alternatives.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

I evaluated several packages to determine which was best.

| package | total mean bench\* | package size |
|-----|-----|-----|
| `json` | 22269.8497 | - |
| `ujson` | 20729.369 | 184K |
| `msgspec` | 22589.6351 | 604K |
| `orjson` | 21399.4234 | 628K |
| `rapidjson` | 20626.785 | 916K |
| `simplejson` | 22365.0746 | 288K |

\* "total mean bench" is the sum of all the mean durations of all benchmarks.

Some packages were faster/slower depending on the lambda event payload. But I ultimately went with `ujson` because it is generally one of the fastest, plus has smallest package size.

**Some benchmark results**

Comparison of `json` and `ujson` when extracting trace context from an sqs batch event.

![benchmark_20240410_182330-test_tracing_extract_dd_trace_context sqs-batch](https://github.com/DataDog/datadog-lambda-python/assets/1383216/54ab0412-f7c1-46ea-ae17-0ab0d7b7f8f5)

Curling lambda url with capture lambda payload true.

<img width="1300" alt="Screenshot 2024-04-10 at 2 57 41 PM" src="https://github.com/DataDog/datadog-lambda-python/assets/1383216/a8a0b425-45df-4d25-a0cf-26c8e9ba463a">




### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
