### PR TITLE
Do not include instrumentation for test runners.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,9 @@ RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/li
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so
 
+RUN rm -rf ./python/lib/$runtime/site-packages/ddtrace/contrib/pytest*
+RUN rm -rf ./python/lib/$runtime/site-packages/ddtrace/contrib/unittest
+RUN rm -rf ./python/lib/$runtime/site-packages/ddtrace/contrib/coverage
+
 FROM scratch
 COPY --from=builder /build/python /


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Removes the following instrumentation libraries from ddtrace:
+ `pytest`
+ `pytest_bdd`
+ `pytest_benchmark`
+ `unittest`
+ `coverage`

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Reduces size of the layer.

Before
```
Layer file .layers/datadog_lambda_py-amd64-3.9.zip has zipped size 3480 kb
Layer file .layers/datadog_lambda_py-amd64-3.9.zip has unzipped size 10485 kb
```

After
```
Layer file .layers/datadog_lambda_py-amd64-3.9.zip has zipped size 3452 kb
Layer file .layers/datadog_lambda_py-amd64-3.9.zip has unzipped size 10393 kb
```

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

These packages are only necessary if customers are running their python tests in lambda and have enabled the testing ci tools. If they are doing this and still want these instrumentations, then they can always vendor their own version of ddtrace.

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)

https://datadoghq.atlassian.net/browse/SVLS-4701