### PR TITLE
Remove unneeded .dist-info files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so
+RUN find . -name "*.dist-info" -type d | xargs rm -rf
+
 
 FROM scratch
 COPY --from=builder /build/python /


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

These files are created by installers (ie pip) and are used to query, uninstall, and otherwise manage installed packages. 

See https://packaging.python.org/en/latest/specifications/recording-installed-packages/
<!--- A brief description of the change being made with this pull request. --->

### Motivation

Reduce package size.

Before
```
Layer file .layers/datadog_lambda_py-arm64-3.12.zip has zipped size 3625 kb
Layer file .layers/datadog_lambda_py-arm64-3.12.zip has unzipped size 11599 kb
```

After
```
Layer file .layers/datadog_lambda_py-arm64-3.12.zip has zipped size 3391 kb
Layer file .layers/datadog_lambda_py-arm64-3.12.zip has unzipped size 11092 kb
```

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)

https://datadoghq.atlassian.net/browse/SVLS-4701