### PR TITLE
[SVLS-4422] Support for metrics with timestamps when the Extension is present

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import base64
-from datadog_lambda.extension import should_use_extension
 
 logger = logging.getLogger(__name__)
 KMS_ENCRYPTION_CONTEXT_KEY = "LambdaFunctionName"
@@ -48,13 +47,10 @@ def decrypt_kms_api_key(kms_client, ciphertext):
 
 
 def init_api():
-    if (
-        not should_use_extension
-        and not os.environ.get("DD_FLUSH_TO_LOG", "").lower() == "true"
-    ):
+    if not os.environ.get("DD_FLUSH_TO_LOG", "").lower() == "true":
         # Make sure that this package would always be lazy-loaded/outside from the critical path
         # since underlying packages are quite heavy to load
-        # and useless when the extension is present
+        # and useless with the extension unless sending metrics with timestamps
         from datadog import api
 
         if not api._api_key:

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -48,7 +48,7 @@ class TestLambdaMetric(unittest.TestCase):
         patcher = patch("datadog_lambda.metric.extension_thread_stats")
         self.mock_metric_extension_thread_stats = patcher.start()
         self.addCleanup(patcher.stop)
-        
+
         lambda_metric("test_timestamp", 1, 123)
         self.mock_metric_lambda_stats.distribution.assert_not_called()
         self.mock_metric_extension_thread_stats.distribution.assert_called_with(

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -43,6 +43,18 @@ class TestLambdaMetric(unittest.TestCase):
         )
         del os.environ["DD_FLUSH_TO_LOG"]
 
+    @patch("datadog_lambda.metric.should_use_extension", True)
+    def test_lambda_metric_timestamp_with_extension(self):
+        patcher = patch("datadog_lambda.metric.extension_thread_stats")
+        self.mock_metric_extension_thread_stats = patcher.start()
+        self.addCleanup(patcher.stop)
+        
+        lambda_metric("test_timestamp", 1, 123)
+        self.mock_metric_lambda_stats.distribution.assert_not_called()
+        self.mock_metric_extension_thread_stats.distribution.assert_called_with(
+            "test_timestamp", 1, timestamp=123, tags=[dd_lambda_layer_tag]
+        )
+
     def test_lambda_metric_flush_to_log(self):
         os.environ["DD_FLUSH_TO_LOG"] = "True"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Adds support for metrics with timestamps (AKA historical metrics) when using the Extension. Dogstatsd does not support historical distribution metrics yet, so we must use the Datadog API client.

We were lazy loading the DD API module when the Extension was not present, so I've tried to be careful not to undo that work. Even with these changes, we should only initialize the API client once per Lambda environment if a timestamp parameter is detected when using `lambda_metric`.

<img width="987" alt="Screenshot 2024-04-26 at 10 50 31 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/25290232/9a24cf93-0c1b-48de-afcc-955f66f17e27">

Flame graph of imported modules on a cold start:

<img width="1304" alt="Screenshot 2024-04-29 at 11 05 53 AM" src="https://github.com/DataDog/datadog-lambda-python/assets/25290232/6f8d892c-c49e-4db8-82f6-33c1d200ddbd">

### Motivation

<!--- What inspired you to submit this pull request? --->
https://github.com/DataDog/datadog-lambda-python/issues/398 

### Testing Guidelines

<!--- How did you test this pull request? --->
Added a simple unit test + manual testing.

### Additional Notes

<!--- Anything else we should know when reviewing? --->
Sister PR for NodeJS: https://github.com/DataDog/datadog-lambda-js/pull/522 

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
