### PR TITLE
Remove extra ddtrace source files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,14 @@ RUN find ./python/lib/$runtime/site-packages -name \*.py | grep -v ddtrace/contr
 RUN find ./python/lib/$runtime/site-packages/ddtrace/contrib -name \*.py | grep -v __init__ | xargs rm -rf
 RUN find ./python/lib/$runtime/site-packages -name __pycache__ -type d -exec rm -r {} \+
 
+# When building ddtrace from branch, remove extra source files.  These are
+# removed by the ddtrace build process before publishing a wheel to PyPI.
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.c -delete
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.cpp -delete
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.cc -delete
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.h -delete
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.hpp -delete
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.pyx -delete
+
 FROM scratch
 COPY --from=builder /build/python /


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Removes `\*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx` files from ddtrace during build.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

When building ddtrace from a branch, it does not perform all the build steps that it would when publishing to PyPI. A missing step is to remove extra source files.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

Make sure integration tests pass.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
