### PR TITLE
[SVLS-4797] safety check before create cold start spans

### DIFF
--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -197,7 +197,8 @@ class ColdStartTracer(object):
 
     def trace_tree(self, import_node: ImportNode, parent_span):
         if (
-            import_node.end_time_ns - import_node.start_time_ns
+            not self.trace_ctx
+            or import_node.end_time_ns - import_node.start_time_ns
             < self.min_duration_ms * 1e6
             or import_node.module_name in self.ignored_libs
         ):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add a one-liner safety check to skip generating cold start spans when the trace context is broken. (Because we have seen this) to avoid creating each cold start tracing node a new trace.
### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
