### PR TITLE
Add rust compiler to base image builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ ARG runtime
 RUN mkdir -p /build/python/lib/$runtime/site-packages
 WORKDIR /build
 
+# Add Rust compiler which is needed to build dd-trace-py from source
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+ENV PATH=/root/.cargo/bin:$PATH
+
 # Install datadog_lambda and dependencies from local
 COPY . .
 RUN pip install . -t ./python/lib/$runtime/site-packages


### PR DESCRIPTION
### What does this PR do?

Install rust compiler in the image builder stage.

### Motivation

This will be needed in order to build dd-trace-py from source in the future

### Testing Guidelines

I updated the `pyproject.toml` to point to a branch of `dd-trace-py` which needs a rust compiler.

I then ran the following command to build the image:

```
docker buildx build -t datadog-lambda-python-amd64 . --no-cache --build-arg "image=python:3.12" --bu
ild-arg "runtime=python3.12" --platform linux/amd64
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
