### PR TITLE
Use sha256 to hash StepFunctions trace id and manually set `_dd.p.tid`

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -97,7 +97,7 @@ integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
   before_script:
     - *install-node
     - EXTERNAL_ID_NAME=integration-test-externalid ROLE_TO_ASSUME=sandbox-integration-test-deployer AWS_ACCOUNT=425362996713 source ./ci/get_secrets.sh
-    - yarn global add serverless --prefix /usr/local
+    - yarn global add serverless@^3.38.0 --prefix /usr/local
     - cd integration_tests && yarn install && cd ..
   script:
     - RUNTIME_PARAM={{ $runtime.python_version }} ARCH={{ $runtime.arch }} ./scripts/run_integration_tests.sh

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -389,10 +389,10 @@ def extract_context_from_step_functions(event, lambda_context):
         parent_id = _deterministic_sha256_hash(
             f"{execution_id}#{state_name}#{state_entered_time}", HIGHER_64_BITS
         )
-        print(f"trace_id: ${trace_id}")
-        print(f"parent_id: ${parent_id}")
+        print(f"trace_id: {trace_id}")
+        print(f"parent_id: {parent_id}")
         print(
-            f"_dd.p.tid: ${hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}"
+            f"_dd.p.tid: {hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}"
         )
 
         sampling_priority = SamplingPriority.AUTO_KEEP

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -396,6 +396,7 @@ def extract_context_from_step_functions(event, lambda_context):
             span_id=parent_id,
             sampling_priority=sampling_priority,
             # take the higher 64 bits as _dd.p.tid tag and use hex to encode
+            # [2:] to remove '0x' in the hex str
             meta={
                 "_dd.p.tid": hex(
                     _deterministic_sha256_hash(execution_id, HIGHER_64_BITS)

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -389,11 +389,6 @@ def extract_context_from_step_functions(event, lambda_context):
         parent_id = _deterministic_sha256_hash(
             f"{execution_id}#{state_name}#{state_entered_time}", HIGHER_64_BITS
         )
-        print(f"trace_id: {trace_id}")
-        print(f"parent_id: {parent_id}")
-        print(
-            f"_dd.p.tid: {hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}"
-        )
 
         sampling_priority = SamplingPriority.AUTO_KEEP
         return Context(

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -75,6 +75,7 @@ DD_TRACE_JAVA_TRACE_ID_PADDING = "00000000"
 HIGHER_64_BITS = "HIGHER_64_BITS"
 LOWER_64_BITS = "LOWER_64_BITS"
 
+
 def _convert_xray_trace_id(xray_trace_id):
     """
     Convert X-Ray trace id (hex)'s last 63 bits to a Datadog trace id (int).
@@ -362,9 +363,9 @@ def _deterministic_sha256_hash(s: str, part: str) -> (int, int):
     # First two chars is '0b'. zfill to ensure 256 bits, but we only care about the first 128 bits
     binary_hash = bin(int(sha256_hash, 16))[2:].zfill(256)
     if part == HIGHER_64_BITS:
-        updated_binary_hash = '0' + binary_hash[1: 64]
+        updated_binary_hash = "0" + binary_hash[1:64]
     else:
-        updated_binary_hash = '0' + binary_hash[65: 128]
+        updated_binary_hash = "0" + binary_hash[65:128]
     result = int(updated_binary_hash, 2)
     if result == 0:
         return 1
@@ -390,13 +391,21 @@ def extract_context_from_step_functions(event, lambda_context):
         )
         print(f"trace_id: ${trace_id}")
         print(f"parent_id: ${parent_id}")
-        print(f"_dd.p.tid: ${hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}")
+        print(
+            f"_dd.p.tid: ${hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}"
+        )
 
         sampling_priority = SamplingPriority.AUTO_KEEP
         return Context(
-            trace_id=trace_id, span_id=parent_id, sampling_priority=sampling_priority,
+            trace_id=trace_id,
+            span_id=parent_id,
+            sampling_priority=sampling_priority,
             # take the higher 64 bits as _dd.p.tid tag and use hex to encode
-            meta={"_dd.p.tid": hex(_deterministic_sha256_hash(execution_id, HIGHER_64_BITS))[2:]}
+            meta={
+                "_dd.p.tid": hex(
+                    _deterministic_sha256_hash(execution_id, HIGHER_64_BITS)
+                )[2:]
+            },
         )
     except Exception as e:
         logger.debug("The Step Functions trace extractor returned with error %s", e)
@@ -1260,9 +1269,9 @@ def create_function_execution_span(
             "function_version": function_version,
             "request_id": context.aws_request_id,
             "resource_names": context.function_name,
-            "functionname": context.function_name.lower()
-            if context.function_name
-            else None,
+            "functionname": (
+                context.function_name.lower() if context.function_name else None
+            ),
             "datadog_lambda": datadog_lambda_version,
             "dd_trace": ddtrace_version,
             "span.name": "aws.lambda",

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -357,7 +357,6 @@ def extract_context_from_kinesis_event(event, lambda_context):
 
 
 def _deterministic_sha256_hash(s: str, part: str) -> (int, int):
-    """MD5 here is to generate trace_id, not for any encryption."""
     sha256_hash = hashlib.sha256(s.encode()).hexdigest()
 
     # First two chars is '0b'. zfill to ensure 256 bits, but we only care about the first 128 bits

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1999,7 +1999,7 @@ class TestStepFunctionsTraceContext(unittest.TestCase):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
             "#lambda#1",
-            HIGHER_64_BITS
+            HIGHER_64_BITS,
         )
         self.assertEqual(3711631873188331089, result)
 
@@ -2007,7 +2007,7 @@ class TestStepFunctionsTraceContext(unittest.TestCase):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
             "#lambda#2",
-            HIGHER_64_BITS
+            HIGHER_64_BITS,
         )
         self.assertEqual(5759173372325510050, result)
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1992,19 +1992,26 @@ class TestInferredSpans(unittest.TestCase):
 
 class TestStepFunctionsTraceContext(unittest.TestCase):
     def test_deterministic_m5_hash(self):
-        result = _deterministic_md5_hash("some_testing_random_string")
-        self.assertEqual(2251275791555400689, result)
+        result = _deterministic_md5_hash("some_testing_random_string", 128)
+        self.assertEqual(80506605202309154694697844088692857990, result)
 
-    def test_deterministic_m5_hash__result_the_same_as_backend(self):
+    def test_deterministic_m5_hash__result_the_same_as_backend_1(self):
         result = _deterministic_md5_hash(
-            "arn:aws:states:sa-east-1:601427271234:express:DatadogStateMachine:acaf1a67-336a-e854-1599-2a627eb2dd8a"
-            ":c8baf081-31f1-464d-971f-70cb17d01111#step-one#2022-12-08T21:08:19.224Z"
+            "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
+            "#lambda#1", 64
         )
-        self.assertEqual(8034507082463708833, result)
+        self.assertEqual(3711631873188331089, result)
+
+    def test_deterministic_m5_hash__result_the_same_as_backend_2(self):
+        result = _deterministic_md5_hash(
+            "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
+            "#lambda#2", 64
+        )
+        self.assertEqual(5759173372325510050, result)
 
     def test_deterministic_m5_hash__always_leading_with_zero(self):
         for i in range(100):
-            result = _deterministic_md5_hash(str(i))
+            result = _deterministic_md5_hash(str(i), 64)
             result_in_binary = bin(int(result))
             # Leading zeros will be omitted, so only test for full 64 bits present
             if len(result_in_binary) == 66:  # "0b" + 64 bits.

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -626,18 +626,20 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         ctx, source, event_source = extract_dd_trace_context(sqs_event, lambda_ctx)
         self.assertEqual(source, "event")
         expected_context = Context(
-            trace_id=1074655265866231755,
-            span_id=4776286484851030060,
+            trace_id=3675572987363469717,
+            span_id=6880978411788117524,
             sampling_priority=1,
+            meta={'_dd.p.tid': 'e987c84b36b11ab'}
         )
         self.assertEqual(ctx, expected_context)
         self.assertEqual(
             get_dd_trace_context(),
             {
-                TraceHeader.TRACE_ID: "1074655265866231755",
-                TraceHeader.PARENT_ID: fake_xray_header_value_parent_decimal,
+                TraceHeader.TRACE_ID: "3675572987363469717",
+                TraceHeader.PARENT_ID: "10713633173203262661",
                 TraceHeader.SAMPLING_PRIORITY: "1",
-            },
+                "x-datadog-tags": '_dd.p.tid=e987c84b36b11ab'
+            }
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called_with(

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1998,14 +1998,16 @@ class TestStepFunctionsTraceContext(unittest.TestCase):
     def test_deterministic_m5_hash__result_the_same_as_backend_1(self):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
-            "#lambda#1", HIGHER_64_BITS
+            "#lambda#1",
+            HIGHER_64_BITS
         )
         self.assertEqual(3711631873188331089, result)
 
     def test_deterministic_m5_hash__result_the_same_as_backend_2(self):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
-            "#lambda#2", HIGHER_64_BITS
+            "#lambda#2",
+            HIGHER_64_BITS
         )
         self.assertEqual(5759173372325510050, result)
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -629,7 +629,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             trace_id=3675572987363469717,
             span_id=6880978411788117524,
             sampling_priority=1,
-            meta={'_dd.p.tid': 'e987c84b36b11ab'}
+            meta={"_dd.p.tid": "e987c84b36b11ab"},
         )
         self.assertEqual(ctx, expected_context)
         self.assertEqual(
@@ -638,8 +638,8 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
                 TraceHeader.TRACE_ID: "3675572987363469717",
                 TraceHeader.PARENT_ID: "10713633173203262661",
                 TraceHeader.SAMPLING_PRIORITY: "1",
-                "x-datadog-tags": '_dd.p.tid=e987c84b36b11ab'
-            }
+                "x-datadog-tags": "_dd.p.tid=e987c84b36b11ab",
+            },
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
         self.mock_send_segment.assert_called_with(

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -20,7 +20,7 @@ from datadog_lambda.constants import (
     XraySubsegment,
 )
 from datadog_lambda.tracing import (
-    _deterministic_md5_hash,
+    _deterministic_sha256_hash,
     create_inferred_span,
     extract_dd_trace_context,
     create_dd_dummy_metadata_subsegment,
@@ -1992,18 +1992,18 @@ class TestInferredSpans(unittest.TestCase):
 
 class TestStepFunctionsTraceContext(unittest.TestCase):
     def test_deterministic_m5_hash(self):
-        result = _deterministic_md5_hash("some_testing_random_string", 128)
+        result = _deterministic_sha256_hash("some_testing_random_string", 128)
         self.assertEqual(80506605202309154694697844088692857990, result)
 
     def test_deterministic_m5_hash__result_the_same_as_backend_1(self):
-        result = _deterministic_md5_hash(
+        result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
             "#lambda#1", 64
         )
         self.assertEqual(3711631873188331089, result)
 
     def test_deterministic_m5_hash__result_the_same_as_backend_2(self):
-        result = _deterministic_md5_hash(
+        result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
             "#lambda#2", 64
         )
@@ -2011,7 +2011,7 @@ class TestStepFunctionsTraceContext(unittest.TestCase):
 
     def test_deterministic_m5_hash__always_leading_with_zero(self):
         for i in range(100):
-            result = _deterministic_md5_hash(str(i), 64)
+            result = _deterministic_sha256_hash(str(i), 64)
             result_in_binary = bin(int(result))
             # Leading zeros will be omitted, so only test for full 64 bits present
             if len(result_in_binary) == 66:  # "0b" + 64 bits.

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -20,7 +20,9 @@ from datadog_lambda.constants import (
     XraySubsegment,
 )
 from datadog_lambda.tracing import (
-    HIGHER_64_BITS, LOWER_64_BITS, _deterministic_sha256_hash,
+    HIGHER_64_BITS,
+    LOWER_64_BITS,
+    _deterministic_sha256_hash,
     create_inferred_span,
     extract_dd_trace_context,
     create_dd_dummy_metadata_subsegment,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -20,7 +20,7 @@ from datadog_lambda.constants import (
     XraySubsegment,
 )
 from datadog_lambda.tracing import (
-    _deterministic_sha256_hash,
+    HIGHER_64_BITS, LOWER_64_BITS, _deterministic_sha256_hash,
     create_inferred_span,
     extract_dd_trace_context,
     create_dd_dummy_metadata_subsegment,
@@ -1992,20 +1992,20 @@ class TestInferredSpans(unittest.TestCase):
 
 class TestStepFunctionsTraceContext(unittest.TestCase):
     def test_deterministic_m5_hash(self):
-        result = _deterministic_sha256_hash("some_testing_random_string", 128)
-        self.assertEqual(80506605202309154694697844088692857990, result)
+        result = _deterministic_sha256_hash("some_testing_random_string", LOWER_64_BITS)
+        self.assertEqual(7456137785171041414, result)
 
     def test_deterministic_m5_hash__result_the_same_as_backend_1(self):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
-            "#lambda#1", 64
+            "#lambda#1", HIGHER_64_BITS
         )
         self.assertEqual(3711631873188331089, result)
 
     def test_deterministic_m5_hash__result_the_same_as_backend_2(self):
         result = _deterministic_sha256_hash(
             "arn:aws:states:sa-east-1:425362996713:stateMachine:MyStateMachine-b276uka1j"
-            "#lambda#2", 64
+            "#lambda#2", HIGHER_64_BITS
         )
         self.assertEqual(5759173372325510050, result)
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- Use sha256 to hash StepFunctions trace context. 
- For 128 bits `trace_id`:
  - The 1st and 65th bits should be `0`.
  - The 1st 64 bits will be converted to base-16 to `_dd.p.tid` tag.
  - The 2nd 64 bits will be put into trace_id in base-10
- For `parent_id` (which is `aws.stepfunctions.lambda` span's span_id in this case):
  - The highest 64 bits will be converted to base-10.
  - The 1st bit should be `0`.
- The trace_id on the APM UI will now be in base-16 instead of base-10.
- [Related PR](https://github.com/DataDog/datadog-lambda-python/pull/320) from the past that uses md5 to hash.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
To support 128 bits trace IDs and to avoid showing up in security vulnerability scans, we are upgrading the hashing method (md5) to sha256.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Tested in staging. The example trace is from a Step Function that triggers two Lambdas. One using NodeJS; another using Python. 
- [example trace](https://dd.datad0g.com/functions?cloud=aws&entity_view=lambda_functions&fromUser=false&graphType=flamegraph&panel_end=1716483562551&panel_paused=false&panel_start=1716479962551&shouldShowLegend=true&sort=time&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Bkimi-test-step-functions-linking%2Bsa-east-1%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%2265ed9415f24950ca6af10dc3ae25a85a%22%2C%22selectedSpanID%22%3A%222432504545734628660%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=2432504545734628660&spanViewType=metadata&text_search=kimi&traceID=65ed9415f24950ca6af10dc3ae25a85a&view=spans&start=1716479482566&end=1716483082566&paused=false)
<img width="1337" alt="image" src="https://github.com/DataDog/datadog-lambda-python/assets/47579703/ed7f4411-6a1c-4ab3-af76-83aeef9183da">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
