### PR TITLE
Pin Serverless to V3 in Python Layer

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -97,7 +97,7 @@ integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
   before_script:
     - *install-node
     - EXTERNAL_ID_NAME=integration-test-externalid ROLE_TO_ASSUME=sandbox-integration-test-deployer AWS_ACCOUNT=425362996713 source ./ci/get_secrets.sh
-    - yarn global add serverless --prefix /usr/local
+    - yarn global add serverless@^3.38.0 --prefix /usr/local
     - cd integration_tests && yarn install && cd ..
   script:
     - RUNTIME_PARAM={{ $runtime.python_version }} ARCH={{ $runtime.arch }} ./scripts/run_integration_tests.sh


### PR DESCRIPTION

```

$ cd integration_tests && yarn install && cd ..
/scripts-1611-521016639/step_script: line 188: cd: integration_tests: No such file or directory
$ RUNTIME_PARAM=3.10 ARCH=arm64 ./scripts/run_integration_tests.sh
Python version is specified: 3.10
Not building layers, ensure they've already been built or re-run with 'BUILD_LAYERS=true DD_API_KEY=XXXX ./scripts/run_integration_tests.sh'
Deploying functions for runtime : python310, serverless runtime : python3.10, python version : 3.10 and run id : 4e80bc69
✖ You must sign in or use a license key with Serverless Framework V.4 and later versions. Please use "serverless login".
Error: You must sign in or use a license key with Serverless Framework V.4 and later versions. Please use "serverless login".
    at getAuthenticatedData (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:710:13913)
    at async authenticate2 (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:989:26220)
    at async Object.resolveServiceConfig (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:989:27565)
    at async file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:1209
    at async route (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:1182)
    at async Object.run2 [as run] (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:4534)
    at async Object.handler (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:7462)
For help, try the following:
  • Run the command again with the "--debug" option
  • Run "serverless support"
  • Review the docs: https://www.serverless.com/framework/docs/
Removing stack for stage : 4e80bc69
✖ You must sign in or use a license key with Serverless Framework V.4 and later versions. Please use "serverless login".
Error: You must sign in or use a license key with Serverless Framework V.4 and later versions. Please use "serverless login".
    at getAuthenticatedData (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:710:13913)
    at async authenticate2 (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:989:26220)
    at async Object.resolveServiceConfig (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:989:27565)
    at async file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:1209
    at async route (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:1182)
    at async Object.run2 [as run] (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:4534)
    at async Object.handler (file:///root/.serverless/releases/4.0.24/package/dist/sf-core.js:992:7462)
For help, try the following:
  • Run the command again with the "--debug" option
  • Run "serverless support"
  • Review the docs: https://www.serverless.com/framework/docs/
```