### PR TITLE
[MLOB-1009] Auto-Instrument LLM Observability

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -225,6 +225,10 @@ class _LambdaDecorator(object):
             # Patch third-party libraries for tracing
             patch_all()
 
+            # Enable LLM Observability
+            if llmobs_env_var:
+                LLMObs.enable()
+
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:
             logger.error(format_err_with_traceback(e))

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -338,9 +338,6 @@ class _LambdaDecorator(object):
             if should_trace_cold_start:
                 trace_ctx = tracer.current_trace_context()
 
-            if llmobs_env_var:
-                LLMObs.flush()
-
             if self.span:
                 if dd_capture_lambda_payload_enabled:
                     tag_object.tag_object(self.span, "function.request", event)
@@ -349,6 +346,9 @@ class _LambdaDecorator(object):
                 if status_code:
                     self.span.set_tag("http.status_code", status_code)
                 self.span.finish()
+
+            if llmobs_env_var:
+                LLMObs.flush()
 
             if self.inferred_span:
                 if status_code:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -54,6 +54,10 @@ profiling_env_var = os.environ.get("DD_PROFILING_ENABLED", "false").lower() == "
 if profiling_env_var:
     from ddtrace.profiling import profiler
 
+llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true", "1")
+if llmobs_env_var:
+    from ddtrace.llmobs import LLMObs
+
 logger = logging.getLogger(__name__)
 
 DD_FLUSH_TO_LOG = "DD_FLUSH_TO_LOG"
@@ -329,6 +333,9 @@ class _LambdaDecorator(object):
             should_trace_cold_start = self.cold_start_tracing and is_new_sandbox()
             if should_trace_cold_start:
                 trace_ctx = tracer.current_trace_context()
+
+            if llmobs_env_var:
+                LLMObs.flush()
 
             if self.span:
                 if dd_capture_lambda_payload_enabled:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -347,9 +347,6 @@ class _LambdaDecorator(object):
                     self.span.set_tag("http.status_code", status_code)
                 self.span.finish()
 
-            if llmobs_env_var:
-                LLMObs.flush()
-
             if self.inferred_span:
                 if status_code:
                     self.inferred_span.set_tag("http.status_code", status_code)
@@ -383,6 +380,9 @@ class _LambdaDecorator(object):
                 # invocation completes because it does not have access to the
                 # logs api
                 flush_extension()
+
+            if llmobs_env_var:
+                LLMObs.flush()
 
             if self.encode_authorizer_context and is_authorizer_response(self.response):
                 self._inject_authorizer_span_headers(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds auto-instrumentation to the serverless layer for LLM Observability. Now, in order to enable LLM Observability for auto-instrumented integrations (OpenAI, LangChain, Bedrock, and Anthropic), set `DD_LLMOBS_ENABLED=1`, along with:
```
DD_LLMOBS_ML_APP=<YOUR_ML_APP>
DD_API_KEY=<YOUR_DATADOG_API_KEY>
DD_SITE=<YOUR_DATADOG_SITE>
```

[LLM Observability documentation](https://docs.datadoghq.com/llm_observability/) is available for full instrumentation instructions.

### Motivation

Enable easy onboarding and auto-instrumentation experience with LLM Observability in a serverless environment.

### Testing Guidelines

Built the layer and tested against a lambda handler. Verified that
1. LLM traces were submitted per invocation of the function
2. APM traces were still being sent as well

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
