### PR TITLE
[SVLS-4999] Add Lambda tags to metrics sent via the API

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -108,11 +108,14 @@ def write_metric_point_to_stdout(metric_name, value, timestamp=None, tags=[]):
     )
 
 
-def flush_stats():
+def flush_stats(lambda_context=None):
     lambda_stats.flush()
 
     if extension_thread_stats is not None:
-        extension_thread_stats.flush()
+        if lambda_context is not None:
+            tags = get_enhanced_metrics_tags(lambda_context)
+            tags.append("function_arn:" + lambda_context.invoked_function_arn)
+        extension_thread_stats.flush(tags)
 
 
 def submit_enhanced_metric(metric_name, lambda_context):

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -62,10 +62,10 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
     if should_use_extension and timestamp is not None:
         # The extension does not support timestamps for distributions so we create a
         # a thread stats writer to submit metrics with timestamps to the API
-        timestampCeiling = int(
+        timestamp_ceiling = int(
             (datetime.now() - timedelta(hours=4)).timestamp()
         )  # 4 hours ago
-        if timestampCeiling > timestamp:
+        if timestamp_ceiling > timestamp:
             logger.warning(
                 "Timestamp %s is older than 4 hours, not submitting metric %s",
                 timestamp,

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -125,7 +125,12 @@ def flush_stats(lambda_context=None):
     if extension_thread_stats is not None:
         if lambda_context is not None:
             tags = get_enhanced_metrics_tags(lambda_context)
-            tags.append("function_arn:" + lambda_context.invoked_function_arn)
+            split_arn = lambda_context.invoked_function_arn.split(":")
+            if len(split_arn) > 7:
+                # Get rid of the alias
+                split_arn.pop()
+            arn = ":".join(split_arn)
+            tags.append("function_arn:" + arn)
         extension_thread_stats.flush(tags)
 
 

--- a/datadog_lambda/thread_stats_writer.py
+++ b/datadog_lambda/thread_stats_writer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 # Make sure that this package would always be lazy-loaded/outside from the critical path
 # since underlying packages are quite heavy to load and useless when the extension is present
@@ -22,11 +23,13 @@ class ThreadStatsWriter(StatsWriter):
             metric_name, value, tags=tags, timestamp=timestamp
         )
 
-    def flush(self):
+    def flush(self, tags=None):
         """ "Flush distributions from ThreadStats to Datadog.
         Modified based on `datadog.threadstats.base.ThreadStats.flush()`,
         to gain better control over exception handling.
         """
+        if tags:
+            self.thread_stats.constant_tags = self.thread_stats.constant_tags + tags
         _, dists = self.thread_stats._get_aggregate_metrics_and_dists(float("inf"))
         count_dists = len(dists)
         if not count_dists:

--- a/datadog_lambda/thread_stats_writer.py
+++ b/datadog_lambda/thread_stats_writer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 # Make sure that this package would always be lazy-loaded/outside from the critical path
 # since underlying packages are quite heavy to load and useless when the extension is present

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -366,7 +366,7 @@ class _LambdaDecorator(object):
                     logger.debug("Failed to create cold start spans. %s", e)
 
             if not self.flush_to_log or should_use_extension:
-                flush_stats()
+                flush_stats(context)
             if should_use_extension and self.local_testing_mode:
                 # when testing locally, the extension does not know when an
                 # invocation completes because it does not have access to the

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -91,7 +91,8 @@ class TestFlushThreadStats(unittest.TestCase):
         self.mock_threadstats_flush_distributions.assert_called_once_with(
             lambda_stats.thread_stats._get_aggregate_metrics_and_dists(float("inf"))[1]
         )
-        self.assertEqual(lambda_stats.thread_stats.constant_tags, tags)
+        for tag in tags:
+            self.assertTrue(tag in lambda_stats.thread_stats.constant_tags)
 
 
 MOCK_FUNCTION_NAME = "myFunction"

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -84,6 +84,15 @@ class TestFlushThreadStats(unittest.TestCase):
         lambda_stats.flush()
         self.assertEqual(self.mock_threadstats_flush_distributions.call_count, 2)
 
+    def test_flush_stats_with_tags(self):
+        lambda_stats = ThreadStatsWriter(True)
+        tags = ["tag1:value1", "tag2:value2"]
+        lambda_stats.flush(tags)
+        self.mock_threadstats_flush_distributions.assert_called_once_with(
+            lambda_stats.thread_stats._get_aggregate_metrics_and_dists(float("inf"))[1]
+        )
+        self.assertEqual(lambda_stats.thread_stats.constant_tags, tags)
+
 
 MOCK_FUNCTION_NAME = "myFunction"
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
When the Extension is present, the Lambda library will use the DD API to send distribution metrics with timestamps instead of the Extension, since the Extension does not support historical distribution metrics. Metrics sent via the API currently do not get tagged with Lambda tags. 

This adds some essential tags like those added via `DD_TAGS` and the `function_arn`. With the `function_arn` tag available, custom metrics will be enriched with other tags collected by the metadata crawler if the AWS integration is enabled:
<img width="450" alt="Screenshot 2024-07-02 at 3 55 16 PM" src="https://github.com/DataDog/datadog-lambda-python/assets/25290232/fc9dd43a-7b69-4b63-8de1-2e52df851350">

Also added a warning log for historical distribution metrics that are sent to the API with an unsupported timestamp (>=4hrs).

### Motivation

<!--- What inspired you to submit this pull request? --->
https://github.com/DataDog/datadog-lambda-js/issues/545 

### Testing Guidelines

<!--- How did you test this pull request? --->
Added tests and manually tested with local builds of the library.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
