### PR TITLE
fix: support dynamic libdd_wrapper.so filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN find . -name 'libddwaf.so' -delete
 RUN rm -rf ./python/lib/$runtime/site-packages/urllib3*
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_taint_tracking/*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
-RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper.so
+RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so
 RUN find . -name "*.dist-info" -type d | xargs rm -rf


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/dd-trace-py/pull/10840 is changing the name of the `libdd_wrapper.so` file, we need to update this `Dockerfile` to support the change in the name.

### Motivation

Without this change, after the release of https://github.com/DataDog/dd-trace-py/pull/10840 the building of this `Dockerfile` will start to fail.

### Testing Guidelines

This was caught in the serverless benchmark job failing with this change.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
