### PR TITLE
Support calling flush_stats with None context.

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -125,6 +125,7 @@ def flush_stats(lambda_context=None):
     lambda_stats.flush()
 
     if extension_thread_stats is not None:
+        tags = None
         if lambda_context is not None:
             tags = get_enhanced_metrics_tags(lambda_context)
             split_arn = lambda_context.invoked_function_arn.split(":")

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -101,9 +101,7 @@ class TestFlushThreadStats(unittest.TestCase):
         self.mock_threadstats_flush_distributions = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch(
-            "datadog_lambda.metric.extension_thread_stats"
-        )
+        patcher = patch("datadog_lambda.metric.extension_thread_stats")
         self.mock_extension_thread_stats = patcher.start()
         self.addCleanup(patcher.stop)
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Ability to call `flush_stats` without a `context`.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
https://github.com/DataDog/datadog-lambda-python/issues/515

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
