### PR TITLE
Upgrade dd-trace-py to v2.14.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,17 +2,17 @@
 
 [[package]]
 name = "boto3"
-version = "1.35.28"
+version = "1.35.31"
 description = "The AWS SDK for Python"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.28-py3-none-any.whl", hash = "sha256:dc088b86a14f17d3cd2e96915c6ccfd31bce640dfe9180df579ed311bc6bf0fc"},
-    {file = "boto3-1.35.28.tar.gz", hash = "sha256:8960fc458b9ba3c8a9890a607c31cee375db821f39aefaec9ff638248e81644a"},
+    {file = "boto3-1.35.31-py3-none-any.whl", hash = "sha256:2e9af74d10d8af7610a8d8468d2914961f116912a024fce17351825260385a52"},
+    {file = "boto3-1.35.31.tar.gz", hash = "sha256:8c593af260c4ea3eb6f079c09908f94494ca2222aa4e40a7ff490fab1cee8b39"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.28,<1.36.0"
+botocore = ">=1.35.31,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -21,13 +21,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.28"
+version = "1.35.31"
 description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.28-py3-none-any.whl", hash = "sha256:b66c78f3d6379bd16f0362f07168fa7699cdda3921fc880047192d96f2c8c527"},
-    {file = "botocore-1.35.28.tar.gz", hash = "sha256:115d13f2172d8e9fa92e8d913f0e80092b97624d190f46772ed2930d4a355d55"},
+    {file = "botocore-1.35.31-py3-none-any.whl", hash = "sha256:4cee814875bc78656aef4011d3d6b2231e96f53ea3661ee428201afb579d5c31"},
+    {file = "botocore-1.35.31.tar.gz", hash = "sha256:f7bfa910cf2cbcc8c2307c1cf7b93495d614c2d699883417893e0a337fe4eb63"},
 ]
 
 [package.dependencies]
@@ -192,71 +192,71 @@ requests = ">=2.6.0"
 
 [[package]]
 name = "ddtrace"
-version = "2.14.0"
+version = "2.14.1"
 description = "Datadog APM client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ddtrace-2.14.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:c55bf165b923a12a1386fbf951735a4b8335a0cfa1558833d2b78abdd289c783"},
-    {file = "ddtrace-2.14.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:b6abaec1263e0ed19fe48d068e02907b7cc6bd312049c4d562f3fe80fcb9e8e5"},
-    {file = "ddtrace-2.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84aff2e9a98172c44b187616838705c7abd4c6e2122e595eb324ba0f269cc7cf"},
-    {file = "ddtrace-2.14.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82c5147d9b27604ac642de32e05fc2d5bac76b15a9ad98b530a585fed347ca86"},
-    {file = "ddtrace-2.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cfb54abfb7b1b1c33a794d926df76e8161bd284a3b15ad55d13290c41b734e95"},
-    {file = "ddtrace-2.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e89d31f3871bee63322dc5d0168d57cfb07ff2581e240510f7103a27e5608046"},
-    {file = "ddtrace-2.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ce4fce7be384bdaae2a4d8600104397352ca71afea6a37a3243f6013031f5d"},
-    {file = "ddtrace-2.14.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81c093b8ad180ce55aec1e6d257de9729a2a2c09dec0fcddc2e7aaede102c32c"},
-    {file = "ddtrace-2.14.0-cp310-cp310-win32.whl", hash = "sha256:b22e13c25af867d92c3b5898e3c01c7dc05ec2ec9975ee54f1ed1ed7ac05969a"},
-    {file = "ddtrace-2.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:d0faab57ee36e054d01fe0684418f20235532411fe470837cce91b60c8aa48a7"},
-    {file = "ddtrace-2.14.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:1f28dbfc35e8e4b3885d55552ef85aa49f66d64291df6212dae878eb057e92e7"},
-    {file = "ddtrace-2.14.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:80cf740482b6f1c65c394e54a6ed269785bfb6319bcd51b91275d671a0d3d2b2"},
-    {file = "ddtrace-2.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f0d07c561238baa8d1d667f315409b9f74a64e77cc2bbad416df6c08d3e9e86"},
-    {file = "ddtrace-2.14.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bbf1c209f5c9b5b505524fe0c5cb3a0f19ece72680d090240af30a6e5172ae23"},
-    {file = "ddtrace-2.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03d7883787db4cd302ebcf6121421d38f3022d98cd04e57473953f0e320f8f4c"},
-    {file = "ddtrace-2.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8cbe7b8848c46e5d7c2efaa4428ea5be9fda699bd69d1d271a8fe805b5554246"},
-    {file = "ddtrace-2.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2286245dc4bfee011851d7e96d4cf15ec59260b54693cae7ffd688ba6d5562a7"},
-    {file = "ddtrace-2.14.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:49214fbfb675f69369339389eea5f399706e9df222b5aba0d92f84f078918074"},
-    {file = "ddtrace-2.14.0-cp311-cp311-win32.whl", hash = "sha256:f8900a124e56e2232c5a34624b45ce7d8e1bba9cad214f2d16dc73a64b30ce09"},
-    {file = "ddtrace-2.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:5f4d340f8c438f6ceb510b4f1fa1a22db14b536420acf8f9d68d5acd95d2e543"},
-    {file = "ddtrace-2.14.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:567cb2254abd0e1e36251ed5a8395c6da6a7f808a854a9fe69ff5a410ab0e586"},
-    {file = "ddtrace-2.14.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:3737025a28090e48eb8c087608b5620056c2b63460889028723bb4918e663293"},
-    {file = "ddtrace-2.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef5f8a4bbe25c9d175c4cf239d63b48a7d26c9ad190b52ac3c27494ff78fc048"},
-    {file = "ddtrace-2.14.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6581d6684afa3d8661e6aff4771edc2b87fcc19628bc0e72724b794a551d3d"},
-    {file = "ddtrace-2.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3c3d834e7e0175c51c2a0fe37ef0bba7f80a00915c000826550ea94e570e5b0"},
-    {file = "ddtrace-2.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5843b6cc83395979f3a17ecb14e14a446795bac64cb4e05bc6eff30be55d014a"},
-    {file = "ddtrace-2.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0209386ee86c95a1ceb245539f81746d4986110c6c974ce1152afbb114531b9a"},
-    {file = "ddtrace-2.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2f1d475562ca82ed79616614a1f11880e580920566fd5ba35b777d738f93affb"},
-    {file = "ddtrace-2.14.0-cp312-cp312-win32.whl", hash = "sha256:83f63720fe40d930b614137d45dc1df5942a440779478f1a192c05ab20fbbbac"},
-    {file = "ddtrace-2.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:0f8bf0a20e9a9094262c59f7237a743cf5aefd20dc29722912a4782e09b2ce1f"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:d7006a90a2200e0692d0c307147020365f244f2043e994aeac9d1c3476d5056f"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a375825022164fab9230b5d51662503953c3d3ef4ae0928f72d3429b8d82067a"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:088f0e67af81096594065327a98058e4b3555a37458214289ddafe0636b752bb"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ffa219e3fa22403e615be2e0669cc1d1d2ca1afa6ef141079ae5e6973306181"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3cd1ffa14bcfc66f3cee0d191ca4681fae602334d9a8044bd5a73b2fc4693454"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7c111498a85693c31ff3e9bd43994ce6734ab960057b36b87e7cbb14e4e90df0"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:4ea1f947b128075c42f1df90f447172a07775cb6c2701698ceaad671dfc71bc7"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-win32.whl", hash = "sha256:de373d0e7cb0a37ee9ff452f344dcca2d525f3d3ec500f175237456d78472d20"},
-    {file = "ddtrace-2.14.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a9880134d03f732503d46b2f75e3febea817827b7d025b7a963bc4d0db892edd"},
-    {file = "ddtrace-2.14.0-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:8a02903585ae581a3b40ad01e062535d8affb3968a408fd96eb48f70615381a4"},
-    {file = "ddtrace-2.14.0-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:b8a1fba689370e5fe956dab6e48f67cb37679fcd26d09fa402f8f4a99472140a"},
-    {file = "ddtrace-2.14.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:073b5cf02bc9302c8132f9ff9db000448a3fd7ba3c3139fc1fb92cd3207d6d96"},
-    {file = "ddtrace-2.14.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86bf04c50fa5ae351c50e716befc5f114993936c18a553d4e177c6272f9df3a4"},
-    {file = "ddtrace-2.14.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dd8d22e61261a04849e89590f4aa81c8a39bd2b7355babf77213fe8c94608bd"},
-    {file = "ddtrace-2.14.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6bb4f00aef805d4e21b16c288823a158f203728e4855f7c8eb7e527c8e49c5c1"},
-    {file = "ddtrace-2.14.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a15180012c57b60469a65be8b6c1f7bdf9372a51b8e8e4de622802f13d770ed1"},
-    {file = "ddtrace-2.14.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:206a01ae3986e09777f0d3d1dc65f1a39d29a77194af07467f3cc9679a60373c"},
-    {file = "ddtrace-2.14.0-cp38-cp38-win32.whl", hash = "sha256:852ca5bb6b5c5bdf8accaf45fda78171d0deecf378ac1efddf69e0f098196807"},
-    {file = "ddtrace-2.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ba1c9de72e059db44b018743c1abee9c4e50f8538567359312595554d3a427e"},
-    {file = "ddtrace-2.14.0-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:a426098d703548802f8d80a76e7740d42b40061493e82b9ab055154dd9837c8f"},
-    {file = "ddtrace-2.14.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:5e72740fcdab45ed919b130f6ae2e5a26c6aaa7a13be94673dee0bce11a561a6"},
-    {file = "ddtrace-2.14.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70b5c386ff3c5b76ad96812fdaf4206660efd51e5ebe98ec46e4eaf8bae5440c"},
-    {file = "ddtrace-2.14.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b262463a46fa178d0257798b84439810dac5de8e81ffc7f6c14350b5a1b9be3e"},
-    {file = "ddtrace-2.14.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf628b5588ea8b14e4bbd0187b7adc7c1fc493bd98df354e9f1da5bd8e8b4e15"},
-    {file = "ddtrace-2.14.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2256ab35a9fc9190fe14bb2af95b769e6c08f872efbeb4ae3ffd7e1ce0a2c650"},
-    {file = "ddtrace-2.14.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:77b73b0878ddfa1a91f74c03b2b9b739fb296b9624ccfe743525d8190e434a6d"},
-    {file = "ddtrace-2.14.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:5c3a34ddc9b8f63d46e32e2b9d52f5ab23e373ae90395f09aef60edb0e6238cb"},
-    {file = "ddtrace-2.14.0-cp39-cp39-win32.whl", hash = "sha256:8a3f5facc044e016ff0529b44ba16d54e56868eb48c6249c03e15cd9407562e5"},
-    {file = "ddtrace-2.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:e9f48394d2a2d1d2ac48fb955d8637b2dd7b055b9033bd686008c12d41b37552"},
-    {file = "ddtrace-2.14.0.tar.gz", hash = "sha256:fb8e851164a4b1f64002d1f76b720281d5cf63eb904f1d04a36bf3c4955b6693"},
+    {file = "ddtrace-2.14.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:45006561033362ae3bf8619e4e23b5f044c1d85ab75f60bfada9cb26b50f3136"},
+    {file = "ddtrace-2.14.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:ec918f63a49f426f0b8507ed045752d31a4fbac6058861dab37e59ea21ec14e6"},
+    {file = "ddtrace-2.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dbef64063312afac39fe3c46aa848e0191b741a31664ce994445c76beb49aa5"},
+    {file = "ddtrace-2.14.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aff1e0749d8bda9e7ec68a3d7c847a02fc6cca8f8a0444c7d33d8c11d6cb9d28"},
+    {file = "ddtrace-2.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9cec95ed8e442efdab682e54b4d200d100c028207a2597fc0e879518f08495b2"},
+    {file = "ddtrace-2.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d0437a4a4e71ae1defb58d940d3efddb3372201bc5ae0ecb960bc5b1684453"},
+    {file = "ddtrace-2.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:66e07bca5bcdb16231bdaf6f848b9d2ab677ab6569185cf33ffceac1406123fb"},
+    {file = "ddtrace-2.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6257295f04950773929ab2586a6b1193015dffdf2e1f915decfb8cce99e7be3e"},
+    {file = "ddtrace-2.14.1-cp310-cp310-win32.whl", hash = "sha256:e57d43bb848a40f4b5efacb3ebece41ddfc4d40b4fb9e5d1b49d43fd33565666"},
+    {file = "ddtrace-2.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:e595d2acba589f2881809c3a1e8302a8ddbfc9d49a546eadf9fb57ee18e39472"},
+    {file = "ddtrace-2.14.1-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:bd5c7274978625688b4eece12deb19704c2ba16187e1e8c35a76b312b6ee587f"},
+    {file = "ddtrace-2.14.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:901e57ed636fbf5b5d002b0348f33d502779cc31d75ac703b63e0b6a84085c07"},
+    {file = "ddtrace-2.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20c4cd8ae87bef85542984ac203f5dd20359daf3a5d7f3f6f7f69736adb0c79e"},
+    {file = "ddtrace-2.14.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ad1fbb0705ff096184e3e5013c6e8f3b7181847ddfb18ea7f8311c3913a5734"},
+    {file = "ddtrace-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a57bb3f8e1bce2e19e3e7effa244bd6cf34a8203692f222c775d8b7d0cd17fa"},
+    {file = "ddtrace-2.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c8e071118dc999d66b94bbe4d927967c76f97a6d10579d75881ee0ecde97baa8"},
+    {file = "ddtrace-2.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:08edf6315429f7b46c760f8726e1f4dd1538c9afd2c02861b5341fd78c39ae5a"},
+    {file = "ddtrace-2.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:707a7c4a0af62234b0d0a8480d9b0c534d57f25a22f554842bceacbd6ad11f96"},
+    {file = "ddtrace-2.14.1-cp311-cp311-win32.whl", hash = "sha256:d52e5cecfddd9b0155792f8f2dc8060337d692a37b24cf8dd862b3026797c1cb"},
+    {file = "ddtrace-2.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:761cbfc629636d38a166f8b8eb5425bdbb29aeaad093095230078257e75572cc"},
+    {file = "ddtrace-2.14.1-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:b7e128001653ad1e24a6705251110c49f8017cb22071de3b77b43bf77978d90b"},
+    {file = "ddtrace-2.14.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:18133ea923613214dfff790a48f4a0cfdfc642804bdb4e3b3e7176848f6b1d8f"},
+    {file = "ddtrace-2.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d59eb2995eec053a7301a07c34795db06ce12b1b86ce787afa3c67ec3bcf6a"},
+    {file = "ddtrace-2.14.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b4aa9aa17f64f2f8e33b9133c5929eebc82773bdf4f739472a4308595bede1e"},
+    {file = "ddtrace-2.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70f78d588a8a11c5b5b12612100fd0e05eb6e85d9c33848555e151b20fa5f2c3"},
+    {file = "ddtrace-2.14.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3cafa9a6663bef1a3caee783f21f5a94c6bb77cf9ab62b9ec6f7c160cdd012aa"},
+    {file = "ddtrace-2.14.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4a9385b52405d069a7cf0d17917a9efafb7261e3d77fe6a3366840e4978e70d9"},
+    {file = "ddtrace-2.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:219ccfd16c0117ab2b26249acb0c88cc0eb0d9543d422ac0ba8f0bfaddb1be2f"},
+    {file = "ddtrace-2.14.1-cp312-cp312-win32.whl", hash = "sha256:97c154e3fb9312fdc926d42204f6aa6966d51a834ef48b5f1655ad8d37b8ee32"},
+    {file = "ddtrace-2.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:0286787a6d883606351b2c59ea21deefdeb80cf07f80d37cf86aef8dd1f17637"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:294583ef333a9cbe5f8ec4906f37dd9dad27d5007a848d291908c1f6df5dabbe"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e863f82f3911242bbcac1c1f9575ba025dae0fc00c57d949b14ca62a27f6dc10"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fee112bd030daf73a26845ebeeb94d2fbdd6aff716643cbad2cf7c68fe722c1"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6705f094130d39f9024831273790d240d1af00c18055377fd7084af693ada600"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ae3461dac55604e035e8fecaf1ae5ef65a3bb0cd6c212966df54316ed46c144e"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7bd0d58fd9b06c1c8b07ce8dd186261f5c102d1c56cebff740874e01dc5936ae"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:5a67f9e97571de6f942f20d6d2f2882b7f257b182a73837ae9dd2b9e1376882b"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-win32.whl", hash = "sha256:0a823207f4b9035cc879d58e9b2121b20d803bf6b5ac1d9359393298625aae10"},
+    {file = "ddtrace-2.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9c33cae0222ade654a77a371ed00d8f62cf37c556effebe19a4e0bfb036775a4"},
+    {file = "ddtrace-2.14.1-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:2bf270159b34c665cdfb9aaac1f7f449dae8665006302a82c97960b74d00dadd"},
+    {file = "ddtrace-2.14.1-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:177ebdb00433aedeefb827e62b65900b8f80781d4b787cd26d219360cebfc1cc"},
+    {file = "ddtrace-2.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a189b7b4645056cca7e60bd7c66bd88d8561a61326214f6ba7b0299c1b192f74"},
+    {file = "ddtrace-2.14.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e444b5d398fb93270740ae43e181ba2693529feb0bbef196525cc6a8981cd0b4"},
+    {file = "ddtrace-2.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39085a8499dbf078081a0ab48fb9e3912386a99325fa70875c07b93325c8e22e"},
+    {file = "ddtrace-2.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c60cba86266502635e0078e0017884c2d685381ce4f009884e49a384bbec100b"},
+    {file = "ddtrace-2.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8a777b6579ca47b7111481d16d1b7fb83ce4356ffc15d3baf38cc5fd28ec1ff0"},
+    {file = "ddtrace-2.14.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:8061bad8fc33981c5d1bd424047595016cc1bf08329492852dd737fcd19516c0"},
+    {file = "ddtrace-2.14.1-cp38-cp38-win32.whl", hash = "sha256:1cfc9200b68f48eaa1382efcb73a66757d44891d2b35707d92b2787d0a710277"},
+    {file = "ddtrace-2.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:9e4ca8d072412d9a1052130cb163f665d01b2314c741bb4809e5bcb1621a9ea3"},
+    {file = "ddtrace-2.14.1-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:2d5d333050abad107eabf2a322753869e0cda4a7daef58b1704ea19cb7b60649"},
+    {file = "ddtrace-2.14.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:3dc5731a22a35726c1e32873e86972e0b36ad44bf4d0c848d4ea0970995889bc"},
+    {file = "ddtrace-2.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3acb996ea7096f6ceebee9e4c84d61e583c7c3f222de6f2ee55981234d74338"},
+    {file = "ddtrace-2.14.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4cbe96ca1985b10e26a920e1a201416fe247f80abb534833a74a43c927c0d69b"},
+    {file = "ddtrace-2.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b7f2483b46a973a1b2271ac2dbf537d3d9e1ab1ed529fc1d3a82cc7b2643dd6"},
+    {file = "ddtrace-2.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:019e0606b2bb38a2d38695165195bf18b23334bd9083a2805bbbec1a48a952d5"},
+    {file = "ddtrace-2.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:55cbb14cd48548ebbacc6abff1b5a226531bc5a36dd063e235b0da8b544ee04f"},
+    {file = "ddtrace-2.14.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:79b01d499a2cf34d8bdf871c82b33d295f4a3d8ab1b25b2e650094d8b0ad7b07"},
+    {file = "ddtrace-2.14.1-cp39-cp39-win32.whl", hash = "sha256:55c9a18c8d1443a6ffa788427f6d7450676eb54619631b31f0220fd16351b4c6"},
+    {file = "ddtrace-2.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:905c7c84681e6ffd59680a8cb9ac5883699a7c4f3ed00b4c8cc25a8b50a60633"},
+    {file = "ddtrace-2.14.1.tar.gz", hash = "sha256:9d7a443824ed84eac2923b8655c45d07aff374088f562dedbb4e7734122bbad5"},
 ]
 
 [package.dependencies]
@@ -604,13 +604,13 @@ files = [
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]
@@ -859,4 +859,4 @@ dev = ["boto3", "flake8", "pytest", "pytest-benchmark", "requests"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0,<4"
-content-hash = "a6aec85347838ba30c70f912ff0d9de03f3089cb658024c1f8d3214baaead760"
+content-hash = "46554f78374b2b0f1d4ea85f984b2a35ffe481f981c360c2f16d534d6c9eb660"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 python = ">=3.8.0,<4"
 datadog = ">=0.41.0,<1.0.0"
 wrapt = "^1.11.2"
-ddtrace = ">=2.14.0"
+ddtrace = ">=2.14.1"
 ujson = ">=5.9.0"
 boto3 = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }


### PR DESCRIPTION
### Motivation

There were some issues with 2.14.0 that got fixed in 2.14.1

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
