### PR TITLE
Add `http.route` tags for API Gateway

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -302,6 +302,7 @@ def extract_http_tags(event):
     # Try to get `routeKey` from API GW v2; otherwise try to get `resource` from API GW v1
     route = event.get("routeKey") or event.get("resource")
     if route:
+        # "GET /my/endpoint" = > "/my/endpoint"
         http_tags["http.route"] = route.split(" ")[-1]
 
     return http_tags

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -299,6 +299,11 @@ def extract_http_tags(event):
     if headers and headers.get("Referer"):
         http_tags["http.referer"] = headers.get("Referer")
 
+    # Try to get `routeKey` from API GW v2; otherwise try to get `resource` from API GW v1
+    route = event.get("routeKey") or event.get("resource")
+    if route:
+        http_tags["http.route"] = route
+
     return http_tags
 
 

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -302,7 +302,7 @@ def extract_http_tags(event):
     # Try to get `routeKey` from API GW v2; otherwise try to get `resource` from API GW v1
     route = event.get("routeKey") or event.get("resource")
     if route:
-        http_tags["http.route"] = route
+        http_tags["http.route"] = route.split(" ")[-1]
 
     return http_tags
 

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -106,6 +106,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -605,6 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -606,7 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -106,6 +106,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -605,6 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -606,7 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -106,6 +106,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -605,6 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -606,7 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -106,6 +106,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -605,6 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -606,7 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -106,6 +106,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -605,6 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -606,7 +606,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -86,6 +86,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -643,7 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -86,6 +86,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -643,7 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -86,6 +86,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -643,7 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -86,6 +86,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -643,7 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -86,6 +86,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
+          "http.route": "/",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
+          "http.route": "GET /httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -643,7 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
-          "http.route": "GET /httpapi/get",
+          "http.route": "/httpapi/get",
           "http.status_code": "200",
           "_dd.base_service": "integration-tests-python"
         },

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -344,7 +344,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url": "x02yirxc7a.execute-api.eu-west-1.amazonaws.com",
                 "http.url_details.path": "/httpapi/get",
                 "http.method": "GET",
-                "http.route": "GET /httpapi/get",
+                "http.route": "/httpapi/get",
             },
         )
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -258,6 +258,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
                 "http.url_details.path": "/prod/path/to/resource",
                 "http.method": "POST",
+                "http.route": "/{proxy+}",
             },
         )
 
@@ -276,6 +277,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url": "lgxbo6a518.execute-api.eu-west-1.amazonaws.com",
                 "http.url_details.path": "/dev/http/get",
                 "http.method": "GET",
+                "http.route": "/http/get",
             },
         )
 
@@ -342,6 +344,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url": "x02yirxc7a.execute-api.eu-west-1.amazonaws.com",
                 "http.url_details.path": "/httpapi/get",
                 "http.method": "GET",
+                "http.route": "GET /httpapi/get",
             },
         )
 


### PR DESCRIPTION
### What does this PR do?
Adds `http.route` tags for Lambdas that were triggered by API Gateway.
- For APIGW v1, we set the route to the resource
- For APIGW v2, we set the route to the routeKey

### Motivation

These tags are used by API Catalog
https://datadoghq.atlassian.net/browse/SVLS-5779

A similar PR for universal instrumentation (Java, .NET, Golang) is already done: https://github.com/DataDog/datadog-agent/commit/315c38f20f75a4a5ce90fcf691d10d3ed286966d

See https://github.com/DataDog/datadog-lambda-js/pull/584 for JavaScript changes.

### Testing Guidelines

Manual tests; update unit tests and snapshots

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
