### PR TITLE
Fix lossiness when submitting timestamped custom metrics

### DIFF
--- a/datadog_lambda/thread_stats_writer.py
+++ b/datadog_lambda/thread_stats_writer.py
@@ -27,8 +27,11 @@ class ThreadStatsWriter(StatsWriter):
         Modified based on `datadog.threadstats.base.ThreadStats.flush()`,
         to gain better control over exception handling.
         """
+        original_constant_tags = self.thread_stats.constant_tags.copy()
         if tags:
-            self.thread_stats.constant_tags = self.thread_stats.constant_tags + tags
+            # Temporarily add tags for this flush
+            self.thread_stats.constant_tags = original_constant_tags + tags
+
         _, dists = self.thread_stats._get_aggregate_metrics_and_dists(float("inf"))
         count_dists = len(dists)
         if not count_dists:
@@ -62,6 +65,9 @@ class ThreadStatsWriter(StatsWriter):
                 logger.debug(
                     "Flush #%s failed", self.thread_stats.flush_count, exc_info=True
                 )
+        finally:
+            # Reset constant_tags to its original state
+            self.thread_stats.constant_tags = original_constant_tags
 
     def stop(self):
         self.thread_stats.stop()


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in `ThreadStatsWriter.flush()` where `constant_tags` were accumulating duplicate tags over multiple Lambda invocations, leading to metric loss for metrics with timestamps. This code was the issue:
```python
if tags:
    self.thread_stats.constant_tags = self.thread_stats.constant_tags + tags
```

Since `self.thread_stats.constant_tags` persists across multiple invocations within the same Lambda execution context, we kept appending duplicate tags after each invocation.

This issue only affected metrics with a timestamp, since they use `ThreadStatsWriter` for submission. After ~12 invocations, the payloads were too large, so custom metrics were being dropped.

This PR modifies the `flush()` method to still add the provided tags, but it now resets `constant_tags` to its original state afterward.

### Motivation

https://github.com/DataDog/datadog-lambda-python/issues/514

### Testing Guidelines

Manual testing showed that metrics were no longer being dropped after these changes.

Added unit tests

### Additional Notes

For people who are more familiar with this library, please make sure that these changes don't have any side effects that I did not consider.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
