### PR TITLE
chore: move aws span pointer helper imports

### DIFF
--- a/datadog_lambda/span_pointers.py
+++ b/datadog_lambda/span_pointers.py
@@ -2,12 +2,6 @@ from itertools import chain
 import logging
 from typing import List
 
-from ddtrace._trace.utils_botocore.span_pointers.dynamodb import (
-    _aws_dynamodb_item_span_pointer_description,
-)
-from ddtrace._trace.utils_botocore.span_pointers.s3 import (
-    _aws_s3_object_span_pointer_description,
-)
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace._span_pointer import _SpanPointerDescription
 from datadog_lambda.trigger import EventTypes
@@ -80,6 +74,10 @@ def _calculate_s3_span_pointers_for_object_created_s3_information(
         return []
 
     try:
+        from ddtrace._trace.utils_botocore.span_pointers.s3 import (
+            _aws_s3_object_span_pointer_description,
+        )
+
         return [
             _aws_s3_object_span_pointer_description(
                 pointer_direction=_SpanPointerDirection.UPSTREAM,
@@ -124,6 +122,10 @@ def _calculate_dynamodb_span_pointers_for_event_record(
         return []
 
     try:
+        from ddtrace._trace.utils_botocore.span_pointers.dynamodb import (
+            _aws_dynamodb_item_span_pointer_description,
+        )
+
         return [
             _aws_dynamodb_item_span_pointer_description(
                 pointer_direction=_SpanPointerDirection.UPSTREAM,


### PR DESCRIPTION
### What does this PR do?

moves some imports.

### Motivation

this way we don't import things we don't absolutely have to.


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
