### PR TITLE
feat: [SVLS-5765] use DD_BOTOCORE_ADD_SPAN_POINTERS

### DIFF
--- a/datadog_lambda/span_pointers.py
+++ b/datadog_lambda/span_pointers.py
@@ -11,7 +11,9 @@ from datadog_lambda.trigger import EventTypes
 logger = logging.getLogger(__name__)
 
 
-dd_botocore_add_span_pointers = os.environ.get("DD_BOTOCORE_ADD_SPAN_POINTERS", "true").lower() in ("true", "1")
+dd_botocore_add_span_pointers = os.environ.get(
+    "DD_BOTOCORE_ADD_SPAN_POINTERS", "true"
+).lower() in ("true", "1")
 
 
 def calculate_span_pointers(


### PR DESCRIPTION
### What does this PR do?

Respect the `DD_BOTOCORE_ADD_SPAN_POINTERS` environment variable that is also used by `dd-trace-py` to opt out of automatic botocore span pointers.

### Testing Guidelines

Unit tests. Also confirmed that this works as expected in a live test lambda setup.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
