### PR TITLE
fix: add typecheck to lambda wrapper

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -411,6 +411,9 @@ def is_legacy_lambda_step_function(event):
     """
     Check if the event is a step function that called a legacy lambda
     """
+    if not isinstance(event, dict):
+        return False
+
     event = event.get("Payload", {})
     return "Execution" in event and "StateMachine" in event and "State" in event
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -411,10 +411,10 @@ def is_legacy_lambda_step_function(event):
     """
     Check if the event is a step function that called a legacy lambda
     """
-    if not isinstance(event, dict):
+    if not isinstance(event, dict) or "Payload" not in event:
         return False
 
-    event = event.get("Payload", {})
+    event = event.get("Payload")
     return "Execution" in event and "StateMachine" in event and "State" in event
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -678,6 +678,9 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         }
         self.assertFalse(is_legacy_lambda_step_function(sf_event))
 
+        other_event = ["foo", "bar"]
+        self.assertFalse(is_legacy_lambda_step_function(other_event))
+
 
 class TestXRayContextConversion(unittest.TestCase):
     def test_convert_xray_trace_id(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

* Checks if `event` is a dictionary before trying to call `get()` on it as it may be a list
* The case where it is a list is breaking instrumentation for customers
* Extended unit tests to catch this

Closes https://github.com/DataDog/datadog-lambda-python/issues/532

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
