### PR TITLE
Prevent error when attempting to use None context.

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -699,6 +699,8 @@ def inject_correlation_ids():
 
 
 def set_dd_trace_py_root(trace_context_source, merge_xray_traces):
+    if not _is_context_complete(dd_trace_context):
+        return
     if trace_context_source == TraceContextSource.EVENT or merge_xray_traces:
         context = Context(
             trace_id=dd_trace_context.trace_id,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -934,6 +934,9 @@ class TestSetTraceRootSpan(unittest.TestCase):
         self.mock_activate = patcher.start()
         self.mock_activate.return_value = True
         self.addCleanup(patcher.stop)
+        patcher = patch("datadog_lambda.tracing.dd_trace_context", None)
+        self.mock_dd_trace_context = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def tearDown(self):
         global dd_tracing_enabled
@@ -990,6 +993,10 @@ class TestSetTraceRootSpan(unittest.TestCase):
         )
         self.mock_activate.assert_called()
         self.mock_activate.assert_has_calls([call(expected_context)])
+
+    def test_set_dd_trace_py_root_none_context(self):
+        set_dd_trace_py_root(TraceContextSource.EVENT, True)
+        self.mock_activate.assert_not_called()
 
 
 class TestServiceMapping(unittest.TestCase):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

When the dd trace context is None, don't continue trying to use it.

### Motivation

<!--- What inspired you to submit this pull request? --->
Self monitoring hit this error:

<img width="742" alt="Screenshot 2024-11-21 at 9 05 39 AM" src="https://github.com/user-attachments/assets/6a9974bb-068d-41c6-996c-4e5efd604e56">


### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

I suspect there are more places in here that need to be addressed.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
