### PR TITLE
Redriven Step Functions Trace Merging

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -392,7 +392,7 @@ def _generate_sfn_parent_id(context: dict) -> int:
     version of the Lambda layer that doesn't use this value for its parentID generation.
     """
     execution_id = context.get("Execution").get("Id")
-    redrive_count = context.get("Execution").get("RedriveCount")
+    redrive_count = context.get("Execution").get("RedriveCount", 0)
     state_name = context.get("State").get("Name")
     state_entered_time = context.get("State").get("EnteredTime")
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -385,11 +385,11 @@ def _parse_high_64_bits(trace_tags: str) -> str:
 
 def _generate_sfn_parent_id(context: dict) -> int:
     """
-    The upstream Step Function can propagate its execution context to downstream Lambdas. The Lambda can use these
-    details to share the same traceID and infer its parent's spanID.
+    The upstream Step Function can propagate its execution context to downstream Lambdas. The
+    Lambda can use these details to share the same traceID and infer its parent's spanID.
 
-    Excluding redriveCount when its 0 to account for cases where customers are using an old version of the Lambda layer
-    that doesn't use this value for its parentID generation.
+    Excluding redriveCount when its 0 to account for cases where customers are using an old
+    version of the Lambda layer that doesn't use this value for its parentID generation.
     """
     execution_id = context.get("Execution").get("Id")
     redrive_count = context.get("Execution").get("RedriveCount")

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -396,8 +396,10 @@ def _generate_sfn_parent_id(context: dict) -> int:
     state_name = context.get("State").get("Name")
     state_entered_time = context.get("State").get("EnteredTime")
 
+    redrive_postfix = "" if redrive_count == "0" else f"#{redrive_count}"
+
     return _deterministic_sha256_hash(
-        f"{execution_id}#{state_name}#{state_entered_time}#{redrive_count}",
+        f"{execution_id}#{state_name}#{state_entered_time}{redrive_postfix}",
         HIGHER_64_BITS,
     )
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -396,7 +396,7 @@ def _generate_sfn_parent_id(context: dict) -> int:
     state_name = context.get("State").get("Name")
     state_entered_time = context.get("State").get("EnteredTime")
 
-    redrive_postfix = "" if redrive_count == "0" else f"#{redrive_count}"
+    redrive_postfix = "" if redrive_count == 0 else f"#{redrive_count}"
 
     return _deterministic_sha256_hash(
         f"{execution_id}#{state_name}#{state_entered_time}{redrive_postfix}",

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -619,31 +619,38 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         lambda_ctx = get_mock_context()
         sfn_event = {
             "Execution": {
-                "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
+                "Id": "arn:aws:states:sa-east-1:425362996713:execution:abhinav-activity-state-machine:72a7ca3e-901c-41bb-b5a3-5f279b92a316",
+                "Name": "72a7ca3e-901c-41bb-b5a3-5f279b92a316",
+                "RoleArn": "arn:aws:iam::425362996713:role/service-role/StepFunctions-abhinav-activity-state-machine-role-22jpbgl6j",
+                "StartTime": "2024-12-04T19:38:04.069Z",
                 "RedriveCount": 0,
             },
-            "StateMachine": {},
             "State": {
-                "Name": "my-awesome-state",
-                "EnteredTime": "Mon Nov 13 12:43:33 PST 2023",
+                "Name": "Lambda Invoke",
+                "EnteredTime": "2024-12-04T19:38:04.118Z",
+                "RetryCount": 0,
+            },
+            "StateMachine": {
+                "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:abhinav-activity-state-machine",
+                "Name": "abhinav-activity-state-machine",
             },
         }
         ctx, source, event_source = extract_dd_trace_context(sfn_event, lambda_ctx)
         self.assertEqual(source, "event")
         expected_context = Context(
-            trace_id=3675572987363469717,
-            span_id=6880978411788117524,
+            trace_id=435175499815315247,
+            span_id=3929055471293792800,
             sampling_priority=1,
-            meta={"_dd.p.tid": "e987c84b36b11ab"},
+            meta={"_dd.p.tid": "3e7a89d1b7310603"},
         )
         self.assertEqual(ctx, expected_context)
         self.assertEqual(
             get_dd_trace_context(),
             {
-                TraceHeader.TRACE_ID: "3675572987363469717",
+                TraceHeader.TRACE_ID: "435175499815315247",
                 TraceHeader.PARENT_ID: "10713633173203262661",
                 TraceHeader.SAMPLING_PRIORITY: "1",
-                TraceHeader.TAGS: "_dd.p.tid=e987c84b36b11ab",
+                TraceHeader.TAGS: "_dd.p.tid=3e7a89d1b7310603",
             },
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)
@@ -652,36 +659,44 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             expected_context,
         )
 
+    # https://github.com/DataDog/logs-backend/blob/c17618cb552fc369ca40282bae0a65803f82f694/domains/serverless/apps/logs-to-traces-reducer/src/test/resources/test-json-files/stepfunctions/RedriveTest/snapshots/RedriveLambdaSuccessTraceMerging.json#L46
     @with_trace_propagation_style("datadog")
     def test_step_function_trace_data_redrive(self):
         lambda_ctx = get_mock_context()
         sfn_event = {
             "Execution": {
-                "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
+                "Id": "arn:aws:states:sa-east-1:425362996713:execution:abhinav-activity-state-machine:72a7ca3e-901c-41bb-b5a3-5f279b92a316",
+                "Name": "72a7ca3e-901c-41bb-b5a3-5f279b92a316",
+                "RoleArn": "arn:aws:iam::425362996713:role/service-role/StepFunctions-abhinav-activity-state-machine-role-22jpbgl6j",
+                "StartTime": "2024-12-04T19:38:04.069Z",
                 "RedriveCount": 1,
             },
-            "StateMachine": {},
             "State": {
-                "Name": "my-awesome-state",
-                "EnteredTime": "Mon Nov 13 12:43:33 PST 2023",
+                "Name": "Lambda Invoke",
+                "EnteredTime": "2024-12-04T19:38:04.118Z",
+                "RetryCount": 0,
+            },
+            "StateMachine": {
+                "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:abhinav-activity-state-machine",
+                "Name": "abhinav-activity-state-machine",
             },
         }
         ctx, source, event_source = extract_dd_trace_context(sfn_event, lambda_ctx)
         self.assertEqual(source, "event")
         expected_context = Context(
-            trace_id=3675572987363469717,
-            span_id=1201185214297576513,
+            trace_id=435175499815315247,
+            span_id=5063839446130725204,
             sampling_priority=1,
-            meta={"_dd.p.tid": "e987c84b36b11ab"},
+            meta={"_dd.p.tid": "3e7a89d1b7310603"},
         )
         self.assertEqual(ctx, expected_context)
         self.assertEqual(
             get_dd_trace_context(),
             {
-                TraceHeader.TRACE_ID: "3675572987363469717",
+                TraceHeader.TRACE_ID: "435175499815315247",
                 TraceHeader.PARENT_ID: "10713633173203262661",
                 TraceHeader.SAMPLING_PRIORITY: "1",
-                TraceHeader.TAGS: "_dd.p.tid=e987c84b36b11ab",
+                TraceHeader.TAGS: "_dd.p.tid=3e7a89d1b7310603",
             },
         )
         create_dd_dummy_metadata_subsegment(ctx, XraySubsegment.TRACE_KEY)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -620,7 +620,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         sfn_event = {
             "Execution": {
                 "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
-                "RedriveCount": "0",
+                "RedriveCount": 0,
             },
             "StateMachine": {},
             "State": {
@@ -658,7 +658,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         sfn_event = {
             "Execution": {
                 "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
-                "RedriveCount": "1",
+                "RedriveCount": 1,
             },
             "StateMachine": {},
             "State": {
@@ -697,7 +697,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             "_datadog": {
                 "Execution": {
                     "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
-                    "RedriveCount": "0",
+                    "RedriveCount": 0,
                 },
                 "StateMachine": {},
                 "State": {
@@ -740,7 +740,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             "_datadog": {
                 "Execution": {
                     "Id": "665c417c-1237-4742-aaca-8b3becbb9e75",
-                    "RedriveCount": "0",
+                    "RedriveCount": 0,
                 },
                 "StateMachine": {},
                 "State": {

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -631,7 +631,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         self.assertEqual(source, "event")
         expected_context = Context(
             trace_id=3675572987363469717,
-            span_id=6880978411788117524,
+            span_id=4929949072763648481,
             sampling_priority=1,
             meta={"_dd.p.tid": "e987c84b36b11ab"},
         )
@@ -673,7 +673,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         self.assertEqual(source, "event")
         expected_context = Context(
             trace_id=5821803790426892636,
-            span_id=6880978411788117524,
+            span_id=4929949072763648481,
             sampling_priority=1,
             meta={"_dd.p.tid": "672a7cb100000000"},
         )
@@ -714,7 +714,7 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
         self.assertEqual(source, "event")
         expected_context = Context(
             trace_id=4521899030418994483,
-            span_id=6880978411788117524,
+            span_id=4929949072763648481,
             sampling_priority=1,
             meta={"_dd.p.tid": "12d1270d99cc5e03"},
         )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -623,7 +623,6 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
                 "Name": "72a7ca3e-901c-41bb-b5a3-5f279b92a316",
                 "RoleArn": "arn:aws:iam::425362996713:role/service-role/StepFunctions-abhinav-activity-state-machine-role-22jpbgl6j",
                 "StartTime": "2024-12-04T19:38:04.069Z",
-                "RedriveCount": 0,
             },
             "State": {
                 "Name": "Lambda Invoke",

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -34,9 +34,9 @@ class TestXRay(unittest.TestCase):
 
     def test_send_segment_sampled_out(self):
         os.environ["AWS_XRAY_DAEMON_ADDRESS"] = "fake-agent.com:8080"
-        os.environ["_X_AMZN_TRACE_ID"] = (
-            "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=0;Lineage=c6c5b1b9:0"
-        )
+        os.environ[
+            "_X_AMZN_TRACE_ID"
+        ] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=0;Lineage=c6c5b1b9:0"
 
         with patch(
             "datadog_lambda.xray.sock.send", MagicMock(return_value=None)
@@ -47,9 +47,9 @@ class TestXRay(unittest.TestCase):
 
     def test_send_segment_sampled(self):
         os.environ["AWS_XRAY_DAEMON_ADDRESS"] = "fake-agent.com:8080"
-        os.environ["_X_AMZN_TRACE_ID"] = (
-            "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0"
-        )
+        os.environ[
+            "_X_AMZN_TRACE_ID"
+        ] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0"
         with patch(
             "datadog_lambda.xray.sock.send", MagicMock(return_value=None)
         ) as mock_send:

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -34,9 +34,9 @@ class TestXRay(unittest.TestCase):
 
     def test_send_segment_sampled_out(self):
         os.environ["AWS_XRAY_DAEMON_ADDRESS"] = "fake-agent.com:8080"
-        os.environ[
-            "_X_AMZN_TRACE_ID"
-        ] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=0;Lineage=c6c5b1b9:0"
+        os.environ["_X_AMZN_TRACE_ID"] = (
+            "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=0;Lineage=c6c5b1b9:0"
+        )
 
         with patch(
             "datadog_lambda.xray.sock.send", MagicMock(return_value=None)
@@ -47,9 +47,9 @@ class TestXRay(unittest.TestCase):
 
     def test_send_segment_sampled(self):
         os.environ["AWS_XRAY_DAEMON_ADDRESS"] = "fake-agent.com:8080"
-        os.environ[
-            "_X_AMZN_TRACE_ID"
-        ] = "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0"
+        os.environ["_X_AMZN_TRACE_ID"] = (
+            "Root=1-5e272390-8c398be037738dc042009320;Parent=94ae789b969f1cc5;Sampled=1;Lineage=c6c5b1b9:0"
+        )
         with patch(
             "datadog_lambda.xray.sock.send", MagicMock(return_value=None)
         ) as mock_send:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for Step Functions trace merging in Redrive cases

We previously used `hash(ExecutionId # StateName # StateEnteredTime)` for spanID calculation but these values are identical across redrives for a Lambda task state. The new approach also adds a `RedriveCount` to the end of the hash but omits this value when it is 0 to have easy backwards compatability.

### Motivation

https://github.com/DataDog/logs-backend/pull/84188

### Testing Guidelines

Redriven [Trace](https://dd.datad0g.com/apm/trace/5be190b56606251d6deb0f8496924f74?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=9522989320986969024&timeHint=1734368341071) with Lambda and Trace Merging
<img width="500" alt="Screenshot 2024-12-16 at 12 00 25 PM" src="https://github.com/user-attachments/assets/4791d8b2-630a-44ba-9f36-b05b4d04dcf1" />

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
