### PR TITLE
use ddtrace.auto since patch_all is being deprecated

### DIFF
--- a/datadog_lambda/patch.py
+++ b/datadog_lambda/patch.py
@@ -11,7 +11,6 @@ import ujson as json
 
 from wrapt import wrap_function_wrapper as wrap
 from wrapt.importer import when_imported
-from ddtrace import patch_all as patch_all_dd
 
 from datadog_lambda.tracing import (
     get_dd_trace_context,
@@ -33,7 +32,7 @@ def patch_all():
     _patch_for_integration_tests()
 
     if dd_tracing_enabled:
-        patch_all_dd()
+        import ddtrace.auto  # noqa: F401
     else:
         _patch_http()
         _ensure_patch_requests()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Replaces the instrumentation mechanism of patch_all() with import ddtrace.auto, since patch_all is being deprecated

### Motivation

https://github.com/DataDog/dd-trace-py/pull/11918
### Testing Guidelines

We'd just hope everything still works as expected

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
