### PR TITLE
Move span pointer to inferred (root) span

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -1368,8 +1368,9 @@ def create_function_execution_span(
     if parent_span:
         span.parent_id = parent_span.span_id
     if span_pointers:
+        root_span = parent_span if parent_span else span
         for span_pointer_description in span_pointers:
-            span._add_span_pointer(
+            root_span._add_span_pointer(
                 pointer_kind=span_pointer_description.pointer_kind,
                 pointer_direction=span_pointer_description.pointer_direction,
                 pointer_hash=span_pointer_description.pointer_hash,


### PR DESCRIPTION
### What does this PR do?

Put span pointers on inferred (root) span instead of the lambda (child) span, as discussed in Slack.

Note that moving the location of the span pointer has no actual effect on the functionality and requires no changes on the UI side. As long as a span is found with a matching hash, span pointers work. Since the spans are on the same trace, this has no noticeable change for our users. 

### Motivation

Discussed in Slack; this change just aligns span pointers with bottlecap (universally instrumented) runtimes.

### Testing Guidelines

Manual testing. See [this span](https://app.datadoghq.com/functions?cloud=aws&config_trace_show_hidden_metadata=true&entity_view=lambda_functions&fromUser=false&graphType=flamegraph&panel_end=1737485434331&panel_paused=false&panel_start=1737484534331&shouldShowLegend=true&sort=time&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Bnhulston-python-test-dev-main%2Bus-east-1%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%2C%7B%22p%22%3A%7B%22traceID%22%3A%22678fec2200000000e5dedcd0a0352fc8%22%2C%22selectedSpanID%22%3A%2213982254895549661893%22%7D%2C%22i%22%3A%22trace-panel%22%7D%5D&spanID=924515743385535558&traceID=678fec2200000000e5dedcd0a0352fc8&start=1737481620000&end=1737485220000&paused=false) and you will see that the span links are on the inferred span now. 

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
