### PR TITLE
feat(ddtrace): upgrade ddtrace version

### DIFF
--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -31,7 +31,7 @@ def set_cold_start(init_timestamp_ns):
         _cold_start = False
         _proactive_initialization = False
     _lambda_container_initialized = True
-    from ddtrace import tracer as _tracer
+    from ddtrace.trace import tracer as _tracer
 
 
 def is_cold_start():

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -30,10 +30,10 @@ from datadog_lambda.xray import (
     parse_xray_header,
 )
 
-from ddtrace import tracer, patch, Span
+from ddtrace import patch
 from ddtrace import __version__ as ddtrace_version
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.context import Context
+from ddtrace.trace import Context, Span, tracer
 from datadog_lambda import __version__ as datadog_lambda_version
 from datadog_lambda.trigger import (
     _EventSource,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 python = ">=3.8.0,<4"
 datadog = ">=0.41.0,<1.0.0"
 wrapt = "^1.11.2"
-ddtrace = ">=2.17.0"
+ddtrace = ">=2.20.0"
 ujson = ">=5.9.0"
 boto3 = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -10,8 +10,8 @@ from unittest.mock import Mock, patch, call
 
 import ddtrace
 
-from ddtrace import tracer
-from ddtrace.context import Context
+from ddtrace.trace import tracer
+from ddtrace.trace import Context
 from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace._span_pointer import _SpanPointerDescription

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -10,7 +10,7 @@ import datadog_lambda.wrapper as wrapper
 import datadog_lambda.xray as xray
 from datadog_lambda.metric import lambda_metric
 from datadog_lambda.thread_stats_writer import ThreadStatsWriter
-from ddtrace import Span, tracer
+from ddtrace.trace import Span, tracer
 from ddtrace.internal.constants import MAX_UINT_64BITS
 
 from tests.utils import get_mock_context, reset_xray_connection


### PR DESCRIPTION
### What does this PR do?

- Upgrades ddtrace to v2.20.0
- Ensures tracing attributes are imported from the new `ddtrace.trace` package.

### Motivation

References to `ddtrace.Span`, `ddtrace.Pin`, and `ddtrace.Tracer` were deprecated in v2.20.0 and will be removed in 3.0. Moving forward tracing attributes must be imported from the `ddtrace.trace` package.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
