### PR TITLE
Lazy load boto client when using datadogpy for metrics.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ datadog = ">=0.51.0,<1.0.0"
 wrapt = "^1.11.2"
 ddtrace = ">=2.20.0,<4"
 ujson = ">=5.9.0"
-boto3 = { version = "^1.34.0", optional = true }
+botocore = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }
 pytest = { version= "^8.0.0", optional = true }
 pytest-benchmark = { version = "^4.0", optional = true }
@@ -38,7 +38,7 @@ flake8 = { version = "^5.0.4", optional = true }
 
 [tool.poetry.extras]
 dev = [
-    "boto3",
+    "botocore",
     "flake8",
     "pytest",
     "pytest-benchmark",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.env_patcher.start()
 
-    @patch("boto3.client")
+    @patch("botocore.session.Session.create_client")
     def test_secrets_manager_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
@@ -42,7 +42,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch("boto3.client")
+    @patch("botocore.session.Session.create_client")
     def test_secrets_manager_different_region(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
@@ -62,7 +62,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch("boto3.client")
+    @patch("botocore.session.Session.create_client")
     def test_ssm_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_parameter.return_value = {
@@ -80,7 +80,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch("boto3.client")
+    @patch("botocore.session.Session.create_client")
     @patch("datadog_lambda.api.decrypt_kms_api_key")
     def test_kms_fips_endpoint(self, mock_decrypt_kms, mock_boto3_client):
         mock_client = MagicMock()
@@ -97,7 +97,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch("boto3.client")
+    @patch("botocore.session.Session.create_client")
     def test_no_fips_for_standard_regions(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Lazy load boto3 and botocore libraries to use only when required.

### Motivation

<!--- What inspired you to submit this pull request? --->

Faster cold starts when using datadogpy for sending metrics.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Original method for creating boto3 client
```py
import boto3
boto3.client('kms')
```

But `boto3.client` code is just (see https://github.com/boto/boto3/blob/2b18684afe102cfd28f9ddc873d7862209d1da69/boto3/__init__.py#L92)
```py
return _get_default_session().client(*args, **kwargs)
```

where `_get_default_session()` is defined as (see https://github.com/boto/boto3/blob/2b18684afe102cfd28f9ddc873d7862209d1da69/boto3/__init__.py#L34)
```py
from boto3.session import Session
DEFAULT_SESSION = Session(**kwargs)
```

The `client` method on a `Session` is just (see https://github.com/boto/boto3/blob/2b18684afe102cfd28f9ddc873d7862209d1da69/boto3/session.py#L215)
```py
return self._session.create_client(*args, **kwargs)
```
Where `self._session` is an instance of `botocore.session.Session` (using `botocore.session.get_session` see https://github.com/boto/boto3/blob/2b18684afe102cfd28f9ddc873d7862209d1da69/boto3/session.py#L62)

Long story short, we can avoid importing all of boto3!!

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
