### PR TITLE
Re-remove iast .so file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
 RUN rm -rf ./python/lib/$runtime/site-packages/setuptools
 RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests
 RUN find . -name 'libddwaf.so' -delete
-RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
-RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper*.so
-RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
+RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_taint_tracking/*.so
+RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
+RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper*.so
+RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
 # _stack_v2 may not exist for some versions of ddtrace (e.g. under python 3.13)
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so
 # remove *.dist-info directories except any entry_points.txt files

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
 RUN rm -rf ./python/lib/$runtime/site-packages/setuptools
 RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests
 RUN find . -name 'libddwaf.so' -delete
-# Comment this line out for now since ddtrace now tries to import it
-# RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
+RUN rm ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper*.so
 RUN rm ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.*.so
 # _stack_v2 may not exist for some versions of ddtrace (e.g. under python 3.13)


### PR DESCRIPTION
Commit https://github.com/DataDog/dd-trace-py/commit/fa18def52e13f863bd8de48cb8ef88feba0caf92 was merged to address this.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Re-removes the `ddtrace/appsec/_iast/_stacktrace*.so` file from our python layers.

### Motivation

<!--- What inspired you to submit this pull request? --->

A change was made by the appsec team to the python tracer which inadvertently caused an import attempt on `ddtrace/appsec/_iast/_stacktrace*.so`. This import would fail when using our python layer. We remove this file because it is large and iast doesn't work in serverless anyway.

I worked with the appsec team directly to address this. They came up with a solution that not only ensures we don't import `ddtrace/appsec/_iast/_stacktrace*.so`, but also makes sure _no_ iast code is imported when iast is disabled.

Now that https://github.com/DataDog/dd-trace-py/pull/12212 is merged, we can go back to safely removing this .so file in our layers.

### Testing Guidelines

<!--- How did you test this pull request? --->

I have another PR open to the python agent (https://github.com/DataDog/dd-trace-py/pull/11888) which will add explicit testing to ensure none of our removed files get imported.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Note that the mentioned PR is merged but not yet released! Do not merge this until that PR has been released!

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
