### PR TITLE
Ddtrace now requires patch.py rather than __init__.py files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,10 @@ RUN rm -rf \
 # https://docs.python.org/3.11/using/cmdline.html#cmdoption-O
 # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONNODEBUGRANGES
 RUN PYTHONNODEBUGRANGES=1 python -OO -m compileall -b ./python/lib/$runtime/site-packages
-# remove all .py files except ddtrace/contrib/*/__init__.py which are necessary
+# remove all .py files except ddtrace/contrib/*/patch.py which are necessary
 # for ddtrace.patch to discover instrumationation packages.
 RUN find ./python/lib/$runtime/site-packages -name \*.py | grep -v ddtrace/contrib | xargs rm -rf
-RUN find ./python/lib/$runtime/site-packages/ddtrace/contrib -name \*.py | grep -v __init__ | xargs rm -rf
+RUN find ./python/lib/$runtime/site-packages/ddtrace/contrib -name \*.py | grep -v patch.py | xargs rm -rf
 RUN find ./python/lib/$runtime/site-packages -name __pycache__ -type d -exec rm -r {} \+
 
 # When building ddtrace from branch, remove extra source files.  These are


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Instead of keeping `__init__.py` files, keep `patch.py` files when building for layer releases.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This change in dd-trace-py https://github.com/DataDog/dd-trace-py/pull/12153/files#diff-6a70144455f9fea41df44b3e578cfaa81ae9c5297e41cce9ef02a5b719013817R265 now means ddtrace looks for `patch.py` files. This change is backported to both the v2 and v3 release lines.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

The integration tests should cover this.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
