### PR TITLE
Enable LLM Observability with `agentless_enabled=True` by default with a parsed API key

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -50,7 +50,8 @@ def decrypt_kms_api_key(kms_client, ciphertext):
 def get_api_key() -> str:
     """
     Gets the Datadog API key from the environment variables or secrets manager.
-    Extracts the result to a global value to avoid repeated calls to the secrets manager from different products.
+    Extracts the result to a global value to avoid repeated calls to the
+    secrets manager from different products.
     """
     global api_key
     if api_key:
@@ -61,9 +62,7 @@ def get_api_key() -> str:
     DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")
     DD_API_KEY_SSM_NAME = os.environ.get("DD_API_KEY_SSM_NAME", "")
     DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
-    DD_API_KEY = os.environ.get(
-        "DD_API_KEY", os.environ.get("DATADOG_API_KEY", "")
-    )
+    DD_API_KEY = os.environ.get("DD_API_KEY", os.environ.get("DATADOG_API_KEY", ""))
 
     if DD_API_KEY_SECRET_ARN:
         api_key = boto3.client("secretsmanager").get_secret_value(

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -4,6 +4,7 @@ import base64
 
 logger = logging.getLogger(__name__)
 KMS_ENCRYPTION_CONTEXT_KEY = "LambdaFunctionName"
+api_key = None
 
 
 def decrypt_kms_api_key(kms_client, ciphertext):
@@ -46,6 +47,41 @@ def decrypt_kms_api_key(kms_client, ciphertext):
     return plaintext
 
 
+def get_api_key() -> str:
+    """
+    Gets the Datadog API key from the environment variables or secrets manager.
+    Extracts the result to a global value to avoid repeated calls to the secrets manager from different products.
+    """
+    global api_key
+    if api_key:
+        return api_key
+
+    import boto3
+
+    DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")
+    DD_API_KEY_SSM_NAME = os.environ.get("DD_API_KEY_SSM_NAME", "")
+    DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
+    DD_API_KEY = os.environ.get(
+        "DD_API_KEY", os.environ.get("DATADOG_API_KEY", "")
+    )
+
+    if DD_API_KEY_SECRET_ARN:
+        api_key = boto3.client("secretsmanager").get_secret_value(
+            SecretId=DD_API_KEY_SECRET_ARN
+        )["SecretString"]
+    elif DD_API_KEY_SSM_NAME:
+        api_key = boto3.client("ssm").get_parameter(
+            Name=DD_API_KEY_SSM_NAME, WithDecryption=True
+        )["Parameter"]["Value"]
+    elif DD_KMS_API_KEY:
+        kms_client = boto3.client("kms")
+        api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
+    else:
+        api_key = DD_API_KEY
+
+    return api_key
+
+
 def init_api():
     if not os.environ.get("DD_FLUSH_TO_LOG", "").lower() == "true":
         # Make sure that this package would always be lazy-loaded/outside from the critical path
@@ -54,28 +90,7 @@ def init_api():
         from datadog import api
 
         if not api._api_key:
-            import boto3
-
-            DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")
-            DD_API_KEY_SSM_NAME = os.environ.get("DD_API_KEY_SSM_NAME", "")
-            DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
-            DD_API_KEY = os.environ.get(
-                "DD_API_KEY", os.environ.get("DATADOG_API_KEY", "")
-            )
-
-            if DD_API_KEY_SECRET_ARN:
-                api._api_key = boto3.client("secretsmanager").get_secret_value(
-                    SecretId=DD_API_KEY_SECRET_ARN
-                )["SecretString"]
-            elif DD_API_KEY_SSM_NAME:
-                api._api_key = boto3.client("ssm").get_parameter(
-                    Name=DD_API_KEY_SSM_NAME, WithDecryption=True
-                )["Parameter"]["Value"]
-            elif DD_KMS_API_KEY:
-                kms_client = boto3.client("kms")
-                api._api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
-            else:
-                api._api_key = DD_API_KEY
+            api._api_key = get_api_key()
 
         logger.debug("Setting DATADOG_API_KEY of length %d", len(api._api_key))
 

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -56,9 +56,15 @@ profiling_env_var = os.environ.get("DD_PROFILING_ENABLED", "false").lower() == "
 if profiling_env_var:
     from ddtrace.profiling import profiler
 
+llmobs_api_key = None
 llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true", "1")
 if llmobs_env_var:
+    from datadog_lambda.api import init_api
+    from datadog import api
     from ddtrace.llmobs import LLMObs
+
+    init_api()
+    llmobs_api_key = api._api_key
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +235,10 @@ class _LambdaDecorator(object):
 
             # Enable LLM Observability
             if llmobs_env_var:
-                LLMObs.enable()
+                LLMObs.enable(
+                    agentless_enabled=True,
+                    api_key=llmobs_api_key,
+                )
 
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -59,12 +59,10 @@ if profiling_env_var:
 llmobs_api_key = None
 llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true", "1")
 if llmobs_env_var:
-    from datadog_lambda.api import init_api
-    from datadog import api
+    from datadog_lambda.api import get_api_key
     from ddtrace.llmobs import LLMObs
 
-    init_api()
-    llmobs_api_key = api._api_key
+    llmobs_api_key = get_api_key()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Enables LLM Observability with `agentless_enabled=True` to ensure seamless compatibility with the agent used in the DD Extension layer. Previously, LLM Observability would try and use an agent proxy endpoint which doesn't exist on the trace agent used in the `next` version of the DD Extension layer. 

Since all we really use the proxy for outside of serverless is so that users don't have to re-state their API key, it should be fine to just use agentless for serverless environments by default (as LLM Observability now also still sends APM traces even if `agentless_enabled=True` is set).

To help enable this, I added a call to `init_api` to get the `DD_API_KEY` from the secrets manager if it lives there, to make the experience even smoother. Otherwise, we can enforce `DD_API_KEY` in the lambda function's env vars

### Motivation

MLOB-2225

### Testing Guidelines

Built the layer with the `build_layers` script, and verified against our LLM Observability lambda functions with only
- `DD_LLMOBS_ENABLED`
- `DD_LLMOBS_ML_APP`
- `DD_API_KEY`

set, and verified traces showed up in the UI.

### Additional Notes

Happy to remove the `init_api` part if it would be too much of a burden on the code path for a serverless env. I saw it was available, and only used for metrics, but decided to re-use. It can be revisited later if needed and we can enforce `DD_API_KEY` being set directly instead.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
