### PR TITLE
Use FIPs endpoints in Govcloud regions

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -98,7 +98,7 @@ def get_api_key() -> str:
         fips_endpoint = (
             f"https://kms-fips.{REGION}.amazonaws.com" if is_gov_region else None
         )
-        kms_client = boto3.client("kms",endpoint_url=fips_endpoint)
+        kms_client = boto3.client("kms", endpoint_url=fips_endpoint)
         api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
     else:
         api_key = DD_API_KEY

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -71,7 +71,11 @@ def get_api_key() -> str:
 
     if DD_API_KEY_SECRET_ARN:
         # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html
-        fips_endpoint = f"https://secretsmanager-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        fips_endpoint = (
+            f"https://secretsmanager-fips.{REGION}.amazonaws.com"
+            if is_gov_region
+            else None
+        )
         secrets_manager_client = boto3.client(
             "secretsmanager", endpoint_url=fips_endpoint
         )
@@ -80,14 +84,22 @@ def get_api_key() -> str:
         )["SecretString"]
     elif DD_API_KEY_SSM_NAME:
         # SSM endpoints: https://docs.aws.amazon.com/general/latest/gr/ssm.html
-        fips_endpoint = f"https://ssm-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        fips_endpoint = (
+            f"https://ssm-fips.{REGION}.amazonaws.com"
+            if is_gov_region
+            else None
+        )
         ssm_client = boto3.client("ssm", endpoint_url=fips_endpoint)
         api_key = ssm_client.get_parameter(
             Name=DD_API_KEY_SSM_NAME, WithDecryption=True
         )["Parameter"]["Value"]
     elif DD_KMS_API_KEY:
         # KMS endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html
-        fips_endpoint = f"https://kms-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        fips_endpoint = (
+            f"https://kms-fips.{REGION}.amazonaws.com"
+            if is_gov_region
+            else None
+        )
         kms_client = boto3.client("kms",endpoint_url=fips_endpoint)
         api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
     else:

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -67,7 +67,9 @@ def get_api_key() -> str:
     REGION = os.environ.get("AWS_REGION", "")
     is_gov_region = REGION.startswith("us-gov-")
     if is_gov_region:
-        logger.info("Govcloud region detected. Using FIPs endpoints for secrets management.")
+        logger.info(
+            "Govcloud region detected. Using FIPs endpoints for secrets management."
+        )
 
     if DD_API_KEY_SECRET_ARN:
         # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html
@@ -85,9 +87,7 @@ def get_api_key() -> str:
     elif DD_API_KEY_SSM_NAME:
         # SSM endpoints: https://docs.aws.amazon.com/general/latest/gr/ssm.html
         fips_endpoint = (
-            f"https://ssm-fips.{REGION}.amazonaws.com"
-            if is_gov_region
-            else None
+            f"https://ssm-fips.{REGION}.amazonaws.com" if is_gov_region else None
         )
         ssm_client = boto3.client("ssm", endpoint_url=fips_endpoint)
         api_key = ssm_client.get_parameter(
@@ -96,9 +96,7 @@ def get_api_key() -> str:
     elif DD_KMS_API_KEY:
         # KMS endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html
         fips_endpoint = (
-            f"https://kms-fips.{REGION}.amazonaws.com"
-            if is_gov_region
-            else None
+            f"https://kms-fips.{REGION}.amazonaws.com" if is_gov_region else None
         )
         kms_client = boto3.client("kms",endpoint_url=fips_endpoint)
         api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -64,16 +64,36 @@ def get_api_key() -> str:
     DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
     DD_API_KEY = os.environ.get("DD_API_KEY", os.environ.get("DATADOG_API_KEY", ""))
 
+    REGION = os.environ.get("AWS_REGION", "")
+    is_gov_region = REGION.startswith("us-gov-")
+
     if DD_API_KEY_SECRET_ARN:
-        api_key = boto3.client("secretsmanager").get_secret_value(
+        # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html
+        fips_endpoint = f"https://secretsmanager-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        secrets_manager_client = boto3.client(
+            "secretsmanager",
+            endpoint_url=fips_endpoint
+        )
+        api_key = secrets_manager_client.get_secret_value(
             SecretId=DD_API_KEY_SECRET_ARN
         )["SecretString"]
     elif DD_API_KEY_SSM_NAME:
-        api_key = boto3.client("ssm").get_parameter(
+        # SSM endpoints: https://docs.aws.amazon.com/general/latest/gr/ssm.html
+        fips_endpoint = f"https://ssm-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        ssm_client = boto3.client(
+            "ssm",
+            endpoint_url=fips_endpoint
+        )
+        api_key = ssm_client.get_parameter(
             Name=DD_API_KEY_SSM_NAME, WithDecryption=True
         )["Parameter"]["Value"]
     elif DD_KMS_API_KEY:
-        kms_client = boto3.client("kms")
+        # KMS endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html
+        fips_endpoint = f"https://kms-fips.{REGION}.amazonaws.com" if is_gov_region else None
+        kms_client = boto3.client(
+            "kms",
+            endpoint_url=fips_endpoint
+        )
         api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
     else:
         api_key = DD_API_KEY

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -71,8 +71,7 @@ def get_api_key() -> str:
         # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html
         fips_endpoint = f"https://secretsmanager-fips.{REGION}.amazonaws.com" if is_gov_region else None
         secrets_manager_client = boto3.client(
-            "secretsmanager",
-            endpoint_url=fips_endpoint
+            "secretsmanager", endpoint_url=fips_endpoint
         )
         api_key = secrets_manager_client.get_secret_value(
             SecretId=DD_API_KEY_SECRET_ARN
@@ -80,20 +79,14 @@ def get_api_key() -> str:
     elif DD_API_KEY_SSM_NAME:
         # SSM endpoints: https://docs.aws.amazon.com/general/latest/gr/ssm.html
         fips_endpoint = f"https://ssm-fips.{REGION}.amazonaws.com" if is_gov_region else None
-        ssm_client = boto3.client(
-            "ssm",
-            endpoint_url=fips_endpoint
-        )
+        ssm_client = boto3.client("ssm", endpoint_url=fips_endpoint)
         api_key = ssm_client.get_parameter(
             Name=DD_API_KEY_SSM_NAME, WithDecryption=True
         )["Parameter"]["Value"]
     elif DD_KMS_API_KEY:
         # KMS endpoints: https://docs.aws.amazon.com/general/latest/gr/kms.html
         fips_endpoint = f"https://kms-fips.{REGION}.amazonaws.com" if is_gov_region else None
-        kms_client = boto3.client(
-            "kms",
-            endpoint_url=fips_endpoint
-        )
+        kms_client = boto3.client("kms",endpoint_url=fips_endpoint)
         api_key = decrypt_kms_api_key(kms_client, DD_KMS_API_KEY)
     else:
         api_key = DD_API_KEY

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -67,7 +67,7 @@ def get_api_key() -> str:
     REGION = os.environ.get("AWS_REGION", "")
     is_gov_region = REGION.startswith("us-gov-")
     if is_gov_region:
-        logger.info(
+        logger.debug(
             "Govcloud region detected. Using FIPs endpoints for secrets management."
         )
 

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -66,6 +66,8 @@ def get_api_key() -> str:
 
     REGION = os.environ.get("AWS_REGION", "")
     is_gov_region = REGION.startswith("us-gov-")
+    if is_gov_region:
+        logger.info("Govcloud region detected. Using FIPs endpoints for secrets management.")
 
     if DD_API_KEY_SECRET_ARN:
         # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 
 import datadog_lambda.api as api
 
+
 class TestDatadogLambdaAPI(unittest.TestCase):
     def setUp(self):
         api.api_key = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,3 +78,11 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
         mock_boto3_client.return_value = mock_client
+
+        os.environ.clear()
+        os.environ["AWS_REGION"] = "us-west-2"
+        os.environ["DD_API_KEY_SECRET_ARN"] = "test-arn"
+
+        api.get_api_key()
+
+        mock_boto3_client.assert_called_with("secretsmanager", endpoint_url=None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,17 +7,21 @@ import datadog_lambda.api as api
 class TestDatadogLambdaAPI(unittest.TestCase):
     def setUp(self):
         api.api_key = None
-        self.env_patcher = patch.dict(os.environ, {
-            "DD_API_KEY_SECRET_ARN": "",
-            "DD_API_KEY_SSM_NAME": "",
-            "DD_KMS_API_KEY": "",
-            "DD_API_KEY": "",
-            "DATADOG_API_KEY": "",
-            "AWS_REGION": "",
-        }, clear=True)
+        self.env_patcher = patch.dict(
+            os.environ,
+            {
+                "DD_API_KEY_SECRET_ARN": "",
+                "DD_API_KEY_SSM_NAME": "",
+                "DD_KMS_API_KEY": "",
+                "DD_API_KEY": "",
+                "DATADOG_API_KEY": "",
+                "AWS_REGION": "",
+            },
+            clear=True,
+        )
         self.env_patcher.start()
 
-    @patch('boto3.client')
+    @patch("boto3.client")
     def test_secrets_manager_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
@@ -30,14 +34,16 @@ class TestDatadogLambdaAPI(unittest.TestCase):
 
         mock_boto3_client.assert_called_with(
             "secretsmanager",
-            endpoint_url="https://secretsmanager-fips.us-gov-east-1.amazonaws.com"
+            endpoint_url="https://secretsmanager-fips.us-gov-east-1.amazonaws.com",
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch('boto3.client')
+    @patch("boto3.client")
     def test_ssm_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
-        mock_client.get_parameter.return_value = {"Parameter": {"Value": "test-api-key"}}
+        mock_client.get_parameter.return_value = {
+            "Parameter": {"Value": "test-api-key"}
+        }
         mock_boto3_client.return_value = mock_client
 
         os.environ["AWS_REGION"] = "us-gov-west-1"
@@ -46,13 +52,12 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         api_key = api.get_api_key()
 
         mock_boto3_client.assert_called_with(
-            "ssm",
-            endpoint_url="https://ssm-fips.us-gov-west-1.amazonaws.com"
+            "ssm", endpoint_url="https://ssm-fips.us-gov-west-1.amazonaws.com"
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch('boto3.client')
-    @patch('datadog_lambda.api.decrypt_kms_api_key')
+    @patch("boto3.client")
+    @patch("datadog_lambda.api.decrypt_kms_api_key")
     def test_kms_fips_endpoint(self, mock_decrypt_kms, mock_boto3_client):
         mock_client = MagicMock()
         mock_boto3_client.return_value = mock_client
@@ -64,21 +69,12 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         api_key = api.get_api_key()
 
         mock_boto3_client.assert_called_with(
-            "kms",
-            endpoint_url="https://kms-fips.us-gov-west-1.amazonaws.com"
+            "kms", endpoint_url="https://kms-fips.us-gov-west-1.amazonaws.com"
         )
         self.assertEqual(api_key, "test-api-key")
 
-    @patch('boto3.client')
+    @patch("boto3.client")
     def test_no_fips_for_standard_regions(self, mock_boto3_client):
         mock_client = MagicMock()
         mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
         mock_boto3_client.return_value = mock_client
-
-        os.environ.clear()
-        os.environ["AWS_REGION"] = "us-west-2"
-        os.environ["DD_API_KEY_SECRET_ARN"] = "test-arn"
-
-        api.get_api_key()
-
-        mock_boto3_client.assert_called_with("secretsmanager", endpoint_url=None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+import datadog_lambda.api as api
+
+class TestDatadogLambdaAPI(unittest.TestCase):
+    def setUp(self):
+        api.api_key = None
+        self.env_patcher = patch.dict(os.environ, {
+            "DD_API_KEY_SECRET_ARN": "",
+            "DD_API_KEY_SSM_NAME": "",
+            "DD_KMS_API_KEY": "",
+            "DD_API_KEY": "",
+            "DATADOG_API_KEY": "",
+            "AWS_REGION": "",
+        }, clear=True)
+        self.env_patcher.start()
+
+    @patch('boto3.client')
+    def test_secrets_manager_fips_endpoint(self, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
+        mock_boto3_client.return_value = mock_client
+
+        os.environ["AWS_REGION"] = "us-gov-east-1"
+        os.environ["DD_API_KEY_SECRET_ARN"] = "test-secrets-arn"
+
+        api_key = api.get_api_key()
+
+        mock_boto3_client.assert_called_with(
+            "secretsmanager",
+            endpoint_url="https://secretsmanager-fips.us-gov-east-1.amazonaws.com"
+        )
+        self.assertEqual(api_key, "test-api-key")
+
+    @patch('boto3.client')
+    def test_ssm_fips_endpoint(self, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_client.get_parameter.return_value = {"Parameter": {"Value": "test-api-key"}}
+        mock_boto3_client.return_value = mock_client
+
+        os.environ["AWS_REGION"] = "us-gov-west-1"
+        os.environ["DD_API_KEY_SSM_NAME"] = "test-ssm-param"
+
+        api_key = api.get_api_key()
+
+        mock_boto3_client.assert_called_with(
+            "ssm",
+            endpoint_url="https://ssm-fips.us-gov-west-1.amazonaws.com"
+        )
+        self.assertEqual(api_key, "test-api-key")
+
+    @patch('boto3.client')
+    @patch('datadog_lambda.api.decrypt_kms_api_key')
+    def test_kms_fips_endpoint(self, mock_decrypt_kms, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_boto3_client.return_value = mock_client
+        mock_decrypt_kms.return_value = "test-api-key"
+
+        os.environ["AWS_REGION"] = "us-gov-west-1"
+        os.environ["DD_KMS_API_KEY"] = "encrypted-api-key"
+
+        api_key = api.get_api_key()
+
+        mock_boto3_client.assert_called_with(
+            "kms",
+            endpoint_url="https://kms-fips.us-gov-west-1.amazonaws.com"
+        )
+        self.assertEqual(api_key, "test-api-key")
+
+    @patch('boto3.client')
+    def test_no_fips_for_standard_regions(self, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
+        mock_boto3_client.return_value = mock_client
+
+        os.environ.clear()
+        os.environ["AWS_REGION"] = "us-west-2"
+        os.environ["DD_API_KEY_SECRET_ARN"] = "test-arn"
+
+        api.get_api_key()
+
+        mock_boto3_client.assert_called_with("secretsmanager", endpoint_url=None)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When creating the Secrets Manager, KMS, or SSM clients, use FIPs endpoints if in Govcloud regions.

### Motivation

Make our products FIPs compliant

### Testing Guidelines

Manually. Works in both commercial and govcloud regions.

### Additional Notes

This part of the code only runs if the Lambda extension is not running, if `lambda_metric` is called with timestamp, or in LLM Observability (https://github.com/DataDog/datadog-lambda-python/pull/572).

Otherwise, the API key is handled by the lambda extension.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
