### PR TITLE
Use correct SecretsManager region

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -83,10 +83,10 @@ def get_api_key() -> str:
         endpoint_url = (
             f"https://secretsmanager-fips.{secrets_region}.amazonaws.com"
             if is_gov_region
-            else f"https://secretsmanager.{secrets_region}.amazonaws.com"
+            else None
         )
         secrets_manager_client = boto3.client(
-            "secretsmanager", endpoint_url=endpoint_url
+            "secretsmanager", endpoint_url=endpoint_url, region_name=secrets_region
         )
         api_key = secrets_manager_client.get_secret_value(
             SecretId=DD_API_KEY_SECRET_ARN

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -76,7 +76,9 @@ def get_api_key() -> str:
         try:
             secrets_region = DD_API_KEY_SECRET_ARN.split(":")[3]
         except Exception as e:
-            logger.debug("Invalid secret arn in DD_API_KEY_SECRET_ARN. Unable to get API key.")
+            logger.debug(
+                "Invalid secret arn in DD_API_KEY_SECRET_ARN. Unable to get API key."
+            )
             return ""
         endpoint_url = (
             f"https://secretsmanager-fips.{secrets_region}.amazonaws.com"

--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -75,7 +75,7 @@ def get_api_key() -> str:
         # Secrets manager endpoints: https://docs.aws.amazon.com/general/latest/gr/asm.html
         try:
             secrets_region = DD_API_KEY_SECRET_ARN.split(":")[3]
-        except Exception as e:
+        except Exception:
             logger.debug(
                 "Invalid secret arn in DD_API_KEY_SECRET_ARN. Unable to get API key."
             )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         mock_boto3_client.assert_called_with(
             "secretsmanager",
             endpoint_url="https://secretsmanager-fips.us-gov-east-1.amazonaws.com",
+            region_name="us-gov-east-1",
         )
         self.assertEqual(api_key, "test-api-key")
 
@@ -56,7 +57,8 @@ class TestDatadogLambdaAPI(unittest.TestCase):
 
         mock_boto3_client.assert_called_with(
             "secretsmanager",
-            endpoint_url="https://secretsmanager.us-west-1.amazonaws.com",
+            endpoint_url=None,
+            region_name="us-west-1",
         )
         self.assertEqual(api_key, "test-api-key")
 
@@ -103,8 +105,12 @@ class TestDatadogLambdaAPI(unittest.TestCase):
 
         os.environ.clear()
         os.environ["AWS_REGION"] = "us-west-2"
-        os.environ["DD_API_KEY_SECRET_ARN"] = "test-arn"
+        os.environ[
+            "DD_API_KEY_SECRET_ARN"
+        ] = "arn:aws:secretsmanager:us-west-2:1234567890:secret:key-name-123ABC"
 
         api.get_api_key()
 
-        mock_boto3_client.assert_called_with("secretsmanager", endpoint_url=None)
+        mock_boto3_client.assert_called_with(
+            "secretsmanager", endpoint_url=None, region_name="us-west-2"
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,13 +29,30 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         mock_boto3_client.return_value = mock_client
 
         os.environ["AWS_REGION"] = "us-gov-east-1"
-        os.environ["DD_API_KEY_SECRET_ARN"] = "test-secrets-arn"
+        os.environ["DD_API_KEY_SECRET_ARN"] = "arn:aws:secretsmanager:us-gov-east-1:1234567890:secret:key-name-123ABC"
 
         api_key = api.get_api_key()
 
         mock_boto3_client.assert_called_with(
             "secretsmanager",
             endpoint_url="https://secretsmanager-fips.us-gov-east-1.amazonaws.com",
+        )
+        self.assertEqual(api_key, "test-api-key")
+
+    @patch("boto3.client")
+    def test_secrets_manager_different_region(self, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
+        mock_boto3_client.return_value = mock_client
+
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["DD_API_KEY_SECRET_ARN"] = "arn:aws:secretsmanager:us-west-1:1234567890:secret:key-name-123ABC"
+
+        api_key = api.get_api_key()
+
+        mock_boto3_client.assert_called_with(
+            "secretsmanager",
+            endpoint_url="https://secretsmanager.us-west-1.amazonaws.com",
         )
         self.assertEqual(api_key, "test-api-key")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,9 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         mock_boto3_client.return_value = mock_client
 
         os.environ["AWS_REGION"] = "us-gov-east-1"
-        os.environ["DD_API_KEY_SECRET_ARN"] = "arn:aws:secretsmanager:us-gov-east-1:1234567890:secret:key-name-123ABC"
+        os.environ[
+            "DD_API_KEY_SECRET_ARN"
+        ] = "arn:aws:secretsmanager:us-gov-east-1:1234567890:secret:key-name-123ABC"
 
         api_key = api.get_api_key()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,9 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         mock_boto3_client.return_value = mock_client
 
         os.environ["AWS_REGION"] = "us-east-1"
-        os.environ["DD_API_KEY_SECRET_ARN"] = "arn:aws:secretsmanager:us-west-1:1234567890:secret:key-name-123ABC"
+        os.environ[
+            "DD_API_KEY_SECRET_ARN"
+        ] = "arn:aws:secretsmanager:us-west-1:1234567890:secret:key-name-123ABC"
 
         api_key = api.get_api_key()
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Users could be storing their secret in SecretsManager in a different region than the currently running Lambda. This parses the arn for the correct region.

Before this change, users would get error: `Secrets Manager can't find the specified secret.`

### Motivation

Backports https://github.com/DataDog/datadog-lambda-extension/pull/604

### Testing Guidelines

Unit tests

- Tested manually with secret in same region, and it works
- Tested manually with secret in different region, and it works

### Additional Notes



### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
