### PR TITLE
Use sam/build-python images for building layers.

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -61,7 +61,7 @@ function docker_build_zip {
     # between different python runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-python-${arch}:$1 . --no-cache \
-        --build-arg image=public.ecr.aws/docker/library/python:$1 \
+        --build-arg image=public.ecr.aws/sam/build-python$1:1 \
         --build-arg runtime=python$1 \
         --platform linux/${arch} \
         --progress=plain \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Changes the base image for building layers.

### Motivation

<!--- What inspired you to submit this pull request? --->

If trying to install ddtrace from source, it will build all of the c binaries. When using the currently defined base image to build ddtrace, it gives the following error when executing the lambda function:

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'datadog_lambda.handler': /lib64/libstdc++.so.6: version 'GLIBCXX_3.4.30' not found (required by /opt/python/lib/python3.12/site-packages/ddtrace/internal/_threads.cpython-312-aarch64-linux-gnu.so)
```

We are guaranteed that the glibc versions will properly match between the sam/build-python images and the lambda/python image.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
