### PR TITLE
Submit metric for DynamoDB Stream Type

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -188,3 +188,12 @@ def submit_errors_metric(lambda_context):
         lambda_context (object): Lambda context dict passed to the function by AWS
     """
     submit_enhanced_metric("errors", lambda_context)
+
+def submit_dynamodb_stream_type_metric(event):
+    stream_view_type = (
+        event.get('Records', [{}])[0]
+        .get('dynamodb', {})
+        .get('StreamViewType')
+    )
+    if stream_view_type:
+        lambda_metric("datadog.serverless.dynamodb.stream.type", 1, timestamp=None, tags=[f"streamtype:{stream_view_type}"], force_async=True)

--- a/datadog_lambda/span_pointers.py
+++ b/datadog_lambda/span_pointers.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace._span_pointer import _SpanPointerDescription
+
+from datadog_lambda.metric import submit_dynamodb_stream_type_metric
 from datadog_lambda.trigger import EventTypes
 
 
@@ -28,6 +30,7 @@ def calculate_span_pointers(
                 return _calculate_s3_span_pointers_for_event(event)
 
             elif event_source.equals(EventTypes.DYNAMODB):
+                submit_dynamodb_stream_type_metric(event) # Temporary metric. TODO eventually remove(@nhulston)
                 return _calculate_dynamodb_span_pointers_for_event(event)
 
     except Exception as e:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Submits a metric for DynamoDB stream type, that we can later query on metabase

### Motivation

Get insights on what stream setting customers are using to come up with a decision regarding: https://docs.google.com/document/d/1phVoU-XtzxjVmECNz3JOC6SJv5GtGj4lbjwXyCv-VUs/edit?tab=t.0#heading=h.ety0x21ybvdr

### Testing Guidelines

Manual
<img width="1339" alt="Screenshot 2025-03-19 at 9 34 22 AM" src="https://github.com/user-attachments/assets/7451081f-89ba-4a10-abe7-98f06c8ebdf9" />

### Additional Notes

PRs to allow us to query on metabase:
https://github.com/DataDog/consul-config/pull/292757
https://github.com/DataDog/consul-config/pull/292758

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
