### PR TITLE
Revert "Use sam/build-python images for building layers."

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -61,7 +61,7 @@ function docker_build_zip {
     # between different python runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-python-${arch}:$1 . --no-cache \
-        --build-arg image=public.ecr.aws/sam/build-python$1:1 \
+        --build-arg image=public.ecr.aws/docker/library/python:$1 \
         --build-arg runtime=python$1 \
         --platform linux/${arch} \
         --progress=plain \


### PR DESCRIPTION
Reverts DataDog/datadog-lambda-python#577