### PR TITLE
chore: lazy load some imports

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import base64
 
 logger = logging.getLogger(__name__)
 KMS_ENCRYPTION_CONTEXT_KEY = "LambdaFunctionName"
@@ -9,6 +8,7 @@ api_key = None
 
 def decrypt_kms_api_key(kms_client, ciphertext):
     from botocore.exceptions import ClientError
+    import base64
 
     """
     Decodes and deciphers the base64-encoded ciphertext given as a parameter using KMS.

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -387,6 +387,7 @@ def extract_context_from_kinesis_event(event, lambda_context):
 
 def _deterministic_sha256_hash(s: str, part: str) -> int:
     import hashlib
+
     sha256_hash = hashlib.sha256(s.encode()).hexdigest()
     # First two chars is '0b'. zfill to ensure 256 bits, but we only care about the first 128 bits
     binary_hash = bin(int(sha256_hash, 16))[2:].zfill(256)

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -4,7 +4,6 @@
 # Copyright 2019 Datadog, Inc.
 import logging
 import os
-import base64
 import traceback
 import ujson as json
 from datetime import datetime, timezone
@@ -258,6 +257,8 @@ def extract_context_from_sqs_or_sns_event_or_context(event, lambda_context):
             dd_json_data = None
             dd_json_data_type = dd_payload.get("Type") or dd_payload.get("dataType")
             if dd_json_data_type == "Binary":
+                import base64
+
                 dd_json_data = dd_payload.get("binaryValue") or dd_payload.get("Value")
                 if dd_json_data:
                     dd_json_data = base64.b64decode(dd_json_data)
@@ -372,6 +373,8 @@ def extract_context_from_kinesis_event(event, lambda_context):
             return extract_context_from_lambda_context(lambda_context)
         data = kinesis.get("data")
         if data:
+            import base64
+
             b64_bytes = data.encode("ascii")
             str_bytes = base64.b64decode(b64_bytes)
             data_str = str_bytes.decode("ascii")
@@ -551,6 +554,8 @@ def get_injected_authorizer_data(event, is_http_api) -> dict:
 
         if not dd_data_raw:
             return None
+
+        import base64
 
         injected_data = json.loads(base64.b64decode(dd_data_raw))
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -2,7 +2,6 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
-import hashlib
 import logging
 import os
 import base64
@@ -387,6 +386,7 @@ def extract_context_from_kinesis_event(event, lambda_context):
 
 
 def _deterministic_sha256_hash(s: str, part: str) -> int:
+    import hashlib
     sha256_hash = hashlib.sha256(s.encode()).hexdigest()
     # First two chars is '0b'. zfill to ensure 256 bits, but we only care about the first 128 bits
     binary_hash = bin(int(sha256_hash, 16))[2:].zfill(256)

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -3,7 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-import base64
 import gzip
 import ujson as json
 from io import BytesIO, BufferedReader
@@ -242,6 +241,8 @@ def parse_event_source_arn(source: _EventSource, event: dict, context: Any) -> s
 
     # e.g. arn:aws:logs:us-west-1:123456789012:log-group:/my-log-group-xyz
     if source.event_type == EventTypes.CLOUDWATCH_LOGS:
+        import base64
+
         with gzip.GzipFile(
             fileobj=BytesIO(base64.b64decode(event.get("awslogs", {}).get("data")))
         ) as decompress_stream:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -244,9 +244,9 @@ class _LambdaDecorator(object):
             return self.response
         except Exception:
             if not should_use_extension:
-                from datadog_lambda.metric import submit_invocations_metric
+                from datadog_lambda.metric import submit_errors_metric
 
-                submit_invocations_metric(context)
+                submit_errors_metric(context)
 
             if self.span:
                 self.span.set_traceback()

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -245,6 +245,7 @@ class _LambdaDecorator(object):
         except Exception:
             if not should_use_extension:
                 from datadog_lambda.metric import submit_invocations_metric
+
                 submit_invocations_metric(context)
 
             if self.span:
@@ -282,9 +283,10 @@ class _LambdaDecorator(object):
         try:
             self.response = None
             set_cold_start(init_timestamp_ns)
-            
+
             if not should_use_extension:
                 from datadog_lambda.metric import submit_invocations_metric
+
                 submit_invocations_metric(context)
 
             self.trigger_tags = extract_trigger_tags(event, context)
@@ -386,6 +388,7 @@ class _LambdaDecorator(object):
 
             if not self.flush_to_log or should_use_extension:
                 from datadog_lambda.metric import flush_stats
+
                 flush_stats(context)
             if should_use_extension and self.local_testing_mode:
                 # when testing locally, the extension does not know when an

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -2,7 +2,6 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
-import base64
 import os
 import logging
 import traceback
@@ -273,6 +272,9 @@ class _LambdaDecorator(object):
         injected_headers[Headers.Parent_Span_Finish_Time] = finish_time_ns
         if request_id is not None:
             injected_headers[Headers.Authorizing_Request_Id] = request_id
+
+        import base64
+
         datadog_data = base64.b64encode(
             json.dumps(injected_headers, escape_forward_slashes=False).encode()
         ).decode()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -470,7 +470,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_write_metric_point_to_stdout.assert_not_called()
 
     def test_only_one_wrapper_in_use(self):
-        patcher = patch("datadog_lambda.wrapper.submit_invocations_metric")
+        patcher = patch("datadog_lambda.metric.submit_invocations_metric")
         self.mock_submit_invocations_metric = patcher.start()
         self.addCleanup(patcher.stop)
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Lazy loads some imports for metrics and hashlib

### Motivation

Metrics submission for invocations and errors doesn't need to be called if there's an extension active.
Hashlib import shouldn't occur unless the method for step functions is called.

### Testing Guidelines

Tested manually

Before:
<img width="489" alt="Screenshot 2025-03-28 at 4 25 43 PM" src="https://github.com/user-attachments/assets/50affc9d-57ce-46d1-aac8-486b5104a9ca" />

After:
<img width="870" alt="Screenshot 2025-03-28 at 4 24 18 PM" src="https://github.com/user-attachments/assets/40c9ae46-ecee-423e-94cf-4cf0d07c06b3" />


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
