### PR TITLE
feat: disable direct metric submission in govcloud

### DIFF
--- a/datadog_lambda/api.py
+++ b/datadog_lambda/api.py
@@ -1,6 +1,8 @@
 import os
 import logging
 
+from datadog_lambda.aws import current_region, running_in_gov_region
+
 logger = logging.getLogger(__name__)
 KMS_ENCRYPTION_CONTEXT_KEY = "LambdaFunctionName"
 api_key = None
@@ -62,8 +64,8 @@ def get_api_key() -> str:
     DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
     DD_API_KEY = os.environ.get("DD_API_KEY", os.environ.get("DATADOG_API_KEY", ""))
 
-    LAMBDA_REGION = os.environ.get("AWS_REGION", "")
-    is_gov_region = LAMBDA_REGION.startswith("us-gov-")
+    LAMBDA_REGION = current_region()
+    is_gov_region = running_in_gov_region()
     if is_gov_region:
         logger.debug(
             "Govcloud region detected. Using FIPs endpoints for secrets management."

--- a/datadog_lambda/aws.py
+++ b/datadog_lambda/aws.py
@@ -1,0 +1,9 @@
+import os
+
+
+def current_region() -> str:
+    return os.environ.get("AWS_REGION", "")
+
+
+def running_in_gov_region() -> bool:
+    return current_region().startswith("us-gov-")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,9 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.env_patcher.start()
 
+    def tearDown(self):
+        self.env_patcher.stop()
+
     @patch("botocore.session.Session.create_client")
     def test_secrets_manager_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -58,6 +58,20 @@ class TestLambdaMetric(unittest.TestCase):
             "test_timestamp", 1, timestamp=timestamp, tags=[dd_lambda_layer_tag]
         )
 
+    @patch("os.environ", {"AWS_REGION": "us-gov-west-1"})
+    @patch("datadog_lambda.metric.should_use_extension", True)
+    def test_lambda_metric_timestamp_with_extension_in_govcloud(self):
+        patcher = patch("datadog_lambda.metric.extension_thread_stats")
+        self.mock_metric_extension_thread_stats = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        delta = timedelta(minutes=1)
+        timestamp = int((datetime.now() - delta).timestamp())
+
+        lambda_metric("test_timestamp", 1, timestamp)
+        self.mock_metric_lambda_stats.distribution.assert_not_called()
+        self.mock_metric_extension_thread_stats.distribution.assert_not_called()
+
     @patch("datadog_lambda.metric.should_use_extension", True)
     def test_lambda_metric_datetime_with_extension(self):
         patcher = patch("datadog_lambda.metric.extension_thread_stats")


### PR DESCRIPTION
### What does this PR do?
Skips metric submission when we're running in govcloud.

### Motivation
We cannot easily guarantee FIPS-compliance of the associated api calls. Let's disable them for now.

### Testing Guidelines
Unit tests, and checking with our self-monitoring stacks.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
