### PR TITLE
[MLOB] revert forced agentless and api key fetching

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -49,13 +49,9 @@ profiling_env_var = os.environ.get("DD_PROFILING_ENABLED", "false").lower() == "
 if profiling_env_var:
     from ddtrace.profiling import profiler
 
-llmobs_api_key = None
 llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true", "1")
 if llmobs_env_var:
-    from datadog_lambda.api import get_api_key
     from ddtrace.llmobs import LLMObs
-
-    llmobs_api_key = get_api_key()
 
 logger = logging.getLogger(__name__)
 
@@ -226,10 +222,7 @@ class _LambdaDecorator(object):
 
             # Enable LLM Observability
             if llmobs_env_var:
-                LLMObs.enable(
-                    agentless_enabled=True,
-                    api_key=llmobs_api_key,
-                )
+                LLMObs.enable()
 
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Reverts forced `agentless_enabled=True` and `api_key` fetching as part of the LLMObs init process for the lambda. 

### Motivation

We recently made a change to [add our endpoints to the extension](https://github.com/DataDog/datadog-lambda-extension/pull/628) and [add a lambda instrument command](https://github.com/DataDog/datadog-ci/pull/1603) to use the latest layer versions and set

- `DD_LLMOBS_ENABLED=true`
- `DD_LLMOBS_AGENTLESS_ENABLED=false` to specifically use the agent in the extension
- `DD_LLMOBS_ML_APP` to whatever was passed into the `--llmobs` command

By using the agent in the extension, we can take advantage of the API secret key parsing there, and reduce the overhead here for importing anything `boto3`-related. Additionally, it's now a more seamless experience overall.

### Testing Guidelines

Verified with a build of the layer with the already-released extension layer.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
