### PR TITLE
Add new region ap-southeast-7.

### DIFF
--- a/ci/datasources/regions.yaml
+++ b/ci/datasources/regions.yaml
@@ -12,6 +12,7 @@ regions:
   - code: "ap-southeast-3"
   - code: "ap-southeast-4"
   - code: "ap-southeast-5"
+  - code: "ap-southeast-7"
   - code: "ap-northeast-1"
   - code: "ap-northeast-2"
   - code: "ap-northeast-3"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->
Here's a screenshot of the available regions in our prod-engineering account. Notice, there is ap-southeast 1 through 5, it skips 6, then there's 7.

This is confirmed in the [aws docs](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html#available-regions).

<img width="291" alt="Screenshot 2025-04-24 at 10 01 04 AM" src="https://github.com/user-attachments/assets/11318bae-3c51-4ba8-af1a-a3ab850af8d7" />


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
