### PR TITLE
feat: Correct FIPS-mode metrics

### DIFF
--- a/datadog_lambda/dogstatsd.py
+++ b/datadog_lambda/dogstatsd.py
@@ -62,7 +62,11 @@ class DogStatsd(object):
 
         >>> statsd.distribution("uploaded.file.size", 1445)
         >>> statsd.distribution("album.photo.count", 26, tags=["gender:female"])
-        >>> statsd.distribution("historic.file.count", 5, timestamp=int(datetime(2020, 2, 14, 12, 0, 0).timestamp()))
+        >>> statsd.distribution(
+        >>>     "historic.file.count",
+        >>>     5,
+        >>>     timestamp=int(datetime(2020, 2, 14, 12, 0, 0).timestamp()),
+        >>> )
         """
         self._report(metric, "d", value, tags, timestamp)
 

--- a/datadog_lambda/dogstatsd.py
+++ b/datadog_lambda/dogstatsd.py
@@ -1,10 +1,9 @@
+import errno
 import logging
 import os
-import socket
-import errno
 import re
+import socket
 from threading import Lock
-
 
 MIN_SEND_BUFFER_SIZE = 32 * 1024
 log = logging.getLogger("datadog_lambda.dogstatsd")
@@ -55,14 +54,17 @@ class DogStatsd(object):
 
         return sock
 
-    def distribution(self, metric, value, tags=None):
+    def distribution(self, metric, value, tags=None, timestamp=None):
         """
-        Send a global distribution value, optionally setting tags.
+        Send a global distribution value, optionally setting tags. The optional
+        timestamp should be an integer representing seconds since the epoch
+        (January 1, 1970, 00:00:00 UTC).
 
         >>> statsd.distribution("uploaded.file.size", 1445)
         >>> statsd.distribution("album.photo.count", 26, tags=["gender:female"])
+        >>> statsd.distribution("historic.file.count", 5, timestamp=int(datetime(2020, 2, 14, 12, 0, 0).timestamp()))
         """
-        self._report(metric, "d", value, tags)
+        self._report(metric, "d", value, tags, timestamp)
 
     def close_socket(self):
         """
@@ -84,20 +86,21 @@ class DogStatsd(object):
             for tag in tag_list
         ]
 
-    def _serialize_metric(self, metric, metric_type, value, tags):
+    def _serialize_metric(self, metric, metric_type, value, tags, timestamp):
         # Create/format the metric packet
-        return "%s:%s|%s%s" % (
+        return "%s:%s|%s%s%s" % (
             metric,
             value,
             metric_type,
             ("|#" + ",".join(self.normalize_tags(tags))) if tags else "",
+            ("|T" + str(timestamp)) if timestamp is not None else "",
         )
 
-    def _report(self, metric, metric_type, value, tags):
+    def _report(self, metric, metric_type, value, tags, timestamp):
         if value is None:
             return
 
-        payload = self._serialize_metric(metric, metric_type, value, tags)
+        payload = self._serialize_metric(metric, metric_type, value, tags, timestamp)
 
         # Send it
         self._send_to_server(payload)

--- a/datadog_lambda/fips.py
+++ b/datadog_lambda/fips.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+is_gov_region = os.environ.get("AWS_REGION", "").startswith("us-gov-")
+
+enable_fips_mode = (
+    os.environ.get(
+        "DD_LAMBDA_FIPS_MODE",
+        "true" if is_gov_region else "false",
+    ).lower()
+    == "true"
+)
+
+if is_gov_region or enable_fips_mode:
+    logger = logging.getLogger(__name__)
+    logger.debug(
+        "Python Lambda Layer FIPS mode is %s.",
+        "enabled" if enable_fips_mode else "not enabled",
+    )

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -41,8 +41,6 @@ def _select_metrics_handler():
 
 
 metrics_handler = _select_metrics_handler()
-# TODO: add a metric for this so that we can see how often the DATADOG_API
-# metrics handler is actually used.
 logger.debug("identified primary metrics handler as %s", metrics_handler)
 
 

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -3,14 +3,15 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
+import logging
 import os
 import time
-import logging
-import ujson as json
 from datetime import datetime, timedelta
 
+import ujson as json
+
 from datadog_lambda.extension import should_use_extension
-from datadog_lambda.tags import get_enhanced_metrics_tags, dd_lambda_layer_tag
+from datadog_lambda.tags import dd_lambda_layer_tag, get_enhanced_metrics_tags
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ else:
     # and leads to data loss. When disabled, metrics are only flushed at the
     # end of invocation. To make metrics submitted from a long-running Lambda
     # function available sooner, consider using the Datadog Lambda extension.
-    from datadog_lambda.thread_stats_writer import ThreadStatsWriter
     from datadog_lambda.api import init_api
+    from datadog_lambda.thread_stats_writer import ThreadStatsWriter
 
     init_api()
     lambda_stats = ThreadStatsWriter(flush_in_thread)
@@ -92,8 +93,8 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
             return
         global extension_thread_stats
         if extension_thread_stats is None:
-            from datadog_lambda.thread_stats_writer import ThreadStatsWriter
             from datadog_lambda.api import init_api
+            from datadog_lambda.thread_stats_writer import ThreadStatsWriter
 
             init_api()
             extension_thread_stats = ThreadStatsWriter(flush_in_thread)
@@ -119,8 +120,10 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
             )
 
 
-def write_metric_point_to_stdout(metric_name, value, timestamp=None, tags=[]):
+def write_metric_point_to_stdout(metric_name, value, timestamp=None, tags=None):
     """Writes the specified metric point to standard output"""
+    tags = tags or []
+
     logger.debug(
         "Sending metric %s value %s to Datadog via log forwarder", metric_name, value
     )

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -16,7 +16,6 @@ from datadog_lambda.tags import dd_lambda_layer_tag, get_enhanced_metrics_tags
 logger = logging.getLogger(__name__)
 
 lambda_stats = None
-extension_thread_stats = None
 
 flush_in_thread = os.environ.get("DD_FLUSH_IN_THREAD", "").lower() == "true"
 
@@ -128,18 +127,6 @@ def write_metric_point_to_stdout(metric_name, value, timestamp=None, tags=None):
 
 def flush_stats(lambda_context=None):
     lambda_stats.flush()
-
-    if extension_thread_stats is not None:
-        tags = None
-        if lambda_context is not None:
-            tags = get_enhanced_metrics_tags(lambda_context)
-            split_arn = lambda_context.invoked_function_arn.split(":")
-            if len(split_arn) > 7:
-                # Get rid of the alias
-                split_arn.pop()
-            arn = ":".join(split_arn)
-            tags.append("function_arn:" + arn)
-        extension_thread_stats.flush(tags)
 
 
 def submit_enhanced_metric(metric_name, lambda_context):

--- a/datadog_lambda/stats_writer.py
+++ b/datadog_lambda/stats_writer.py
@@ -1,5 +1,5 @@
 class StatsWriter:
-    def distribution(self, metric_name, value, tags=[], timestamp=None):
+    def distribution(self, metric_name, value, tags=None, timestamp=None):
         raise NotImplementedError()
 
     def flush(self):

--- a/datadog_lambda/statsd_writer.py
+++ b/datadog_lambda/statsd_writer.py
@@ -1,5 +1,5 @@
-from datadog_lambda.stats_writer import StatsWriter
 from datadog_lambda.dogstatsd import statsd
+from datadog_lambda.stats_writer import StatsWriter
 
 
 class StatsDWriter(StatsWriter):
@@ -7,8 +7,8 @@ class StatsDWriter(StatsWriter):
     Writes distribution metrics using StatsD protocol
     """
 
-    def distribution(self, metric_name, value, tags=[], timestamp=None):
-        statsd.distribution(metric_name, value, tags=tags)
+    def distribution(self, metric_name, value, tags=None, timestamp=None):
+        statsd.distribution(metric_name, value, tags=tags, timestamp=timestamp)
 
     def flush(self):
         pass

--- a/datadog_lambda/thread_stats_writer.py
+++ b/datadog_lambda/thread_stats_writer.py
@@ -3,6 +3,7 @@ import logging
 # Make sure that this package would always be lazy-loaded/outside from the critical path
 # since underlying packages are quite heavy to load and useless when the extension is present
 from datadog.threadstats import ThreadStats
+
 from datadog_lambda.stats_writer import StatsWriter
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,7 @@ class ThreadStatsWriter(StatsWriter):
         self.thread_stats = ThreadStats(compress_payload=True)
         self.thread_stats.start(flush_in_thread=flush_in_thread)
 
-    def distribution(self, metric_name, value, tags=[], timestamp=None):
+    def distribution(self, metric_name, value, tags=None, timestamp=None):
         self.thread_stats.distribution(
             metric_name, value, tags=tags, timestamp=timestamp
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import datadog_lambda.api as api
 
@@ -22,6 +22,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.env_patcher.start()
 
+    @patch("datadog_lambda.api.enable_fips_mode", True)
     @patch("botocore.session.Session.create_client")
     def test_secrets_manager_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
@@ -62,6 +63,28 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
+    @patch("datadog_lambda.api.enable_fips_mode", True)
+    @patch("botocore.session.Session.create_client")
+    def test_secrets_manager_different_region_but_still_fips(self, mock_boto3_client):
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": "test-api-key"}
+        mock_boto3_client.return_value = mock_client
+
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ[
+            "DD_API_KEY_SECRET_ARN"
+        ] = "arn:aws:secretsmanager:us-west-1:1234567890:secret:key-name-123ABC"
+
+        api_key = api.get_api_key()
+
+        mock_boto3_client.assert_called_with(
+            "secretsmanager",
+            endpoint_url="https://secretsmanager-fips.us-west-1.amazonaws.com",
+            region_name="us-west-1",
+        )
+        self.assertEqual(api_key, "test-api-key")
+
+    @patch("datadog_lambda.api.enable_fips_mode", True)
     @patch("botocore.session.Session.create_client")
     def test_ssm_fips_endpoint(self, mock_boto3_client):
         mock_client = MagicMock()
@@ -80,6 +103,7 @@ class TestDatadogLambdaAPI(unittest.TestCase):
         )
         self.assertEqual(api_key, "test-api-key")
 
+    @patch("datadog_lambda.api.enable_fips_mode", True)
     @patch("botocore.session.Session.create_client")
     @patch("datadog_lambda.api.decrypt_kms_api_key")
     def test_kms_fips_endpoint(self, mock_decrypt_kms, mock_boto3_client):

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -44,10 +44,6 @@ class TestLambdaMetric(unittest.TestCase):
 
     @patch("datadog_lambda.metric.should_use_extension", True)
     def test_lambda_metric_timestamp_with_extension(self):
-        patcher = patch("datadog_lambda.metric.extension_thread_stats")
-        self.mock_metric_extension_thread_stats = patcher.start()
-        self.addCleanup(patcher.stop)
-
         delta = timedelta(minutes=1)
         timestamp = int((datetime.now() - delta).timestamp())
 
@@ -55,14 +51,9 @@ class TestLambdaMetric(unittest.TestCase):
         self.mock_metric_lambda_stats.distribution.assert_has_calls(
             [call("test_timestamp", 1, timestamp=timestamp, tags=[dd_lambda_layer_tag])]
         )
-        self.mock_metric_extension_thread_stats.distribution.assert_not_called()
 
     @patch("datadog_lambda.metric.should_use_extension", True)
     def test_lambda_metric_datetime_with_extension(self):
-        patcher = patch("datadog_lambda.metric.extension_thread_stats")
-        self.mock_metric_extension_thread_stats = patcher.start()
-        self.addCleanup(patcher.stop)
-
         delta = timedelta(minutes=1)
         timestamp = datetime.now() - delta
 
@@ -77,20 +68,14 @@ class TestLambdaMetric(unittest.TestCase):
                 )
             ]
         )
-        self.mock_metric_extension_thread_stats.distribution.assert_not_called()
 
     @patch("datadog_lambda.metric.should_use_extension", True)
     def test_lambda_metric_invalid_timestamp_with_extension(self):
-        patcher = patch("datadog_lambda.metric.extension_thread_stats")
-        self.mock_metric_extension_thread_stats = patcher.start()
-        self.addCleanup(patcher.stop)
-
         delta = timedelta(hours=5)
         timestamp = int((datetime.now() - delta).timestamp())
 
         lambda_metric("test_timestamp", 1, timestamp)
         self.mock_metric_lambda_stats.distribution.assert_not_called()
-        self.mock_metric_extension_thread_stats.distribution.assert_not_called()
 
     def test_lambda_metric_flush_to_log(self):
         os.environ["DD_FLUSH_TO_LOG"] = "True"
@@ -133,10 +118,6 @@ class TestFlushThreadStats(unittest.TestCase):
             "datadog.threadstats.reporters.HttpReporter.flush_distributions"
         )
         self.mock_threadstats_flush_distributions = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = patch("datadog_lambda.metric.extension_thread_stats")
-        self.mock_extension_thread_stats = patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_retry_on_remote_disconnected(self):
@@ -216,10 +197,6 @@ class TestFlushThreadStats(unittest.TestCase):
             self.assertEqual(
                 lambda_stats.thread_stats.constant_tags, original_constant_tags
             )
-
-    def test_flush_stats_without_context(self):
-        flush_stats(lambda_context=None)
-        self.mock_extension_thread_stats.flush.assert_called_with(None)
 
 
 MOCK_FUNCTION_NAME = "myFunction"


### PR DESCRIPTION
- Our `dogstatsd` client now supports timestamps for the metrics that it will send.
- This unblocks us to always send metrics to the extension, even if they have a timestamp. Confirmed that this actually works now with both bottlecap and the go agent.
- Refactored the metrics workflow to have an explicit choice of metrics handlers (Extension, Forwarder, Datadog API, or, for some FIPS usecases, No Handler).
- Added a `DD_LAMBDA_FIPS_MODE` flag which allows FIPS-mode logic to be enabled in commercial regions or disabled in govcloud regions.
- The new FIPS mode is used for Datadog API Key secret lookup and for metrics handling decisions.

### Breaking Change
Since the `DD_LAMBDA_FIPS_MODE` defaults to `true` in govcloud, direct metrics submission there (without an Extension or a Forwarder) will now be disabled.

### Testing Guidelines
Unit tests were added or updated. Also confirmed with test apps that this logic works as expected.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
