### PR TITLE
fix: timestamps we send to the extension should be integers

### DIFF
--- a/datadog_lambda/dogstatsd.py
+++ b/datadog_lambda/dogstatsd.py
@@ -97,7 +97,7 @@ class DogStatsd(object):
             value,
             metric_type,
             ("|#" + ",".join(self.normalize_tags(tags))) if tags else "",
-            ("|T" + str(timestamp)) if timestamp is not None else "",
+            ("|T" + str(int(timestamp))) if timestamp is not None else "",
         )
 
     def _report(self, metric, metric_type, value, tags, timestamp):

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -111,6 +111,18 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None, force_async=Fal
             if isinstance(timestamp, datetime):
                 timestamp = int(timestamp.timestamp())
 
+            else:
+                try:
+                    timestamp = int(timestamp)
+                except Exception:
+                    logger.debug(
+                        "Ignoring metric submission for metric '%s' because the timestamp cannot "
+                        "be turned into an integer: %r",
+                        metric_name,
+                        timestamp,
+                    )
+                    return
+
             timestamp_floor = int((datetime.now() - timedelta(hours=4)).timestamp())
             if timestamp < timestamp_floor:
                 logger.warning(

--- a/tests/test_dogstatsd.py
+++ b/tests/test_dogstatsd.py
@@ -53,3 +53,7 @@ class TestDogStatsd(unittest.TestCase):
     def test_distribution_with_timestamp(self):
         statsd.distribution("my.test.timestamp.metric", 9, timestamp=123456789)
         self._checkOnlyOneMetric("my.test.timestamp.metric:9|d|T123456789")
+
+    def test_distribution_with_float_timestamp(self):
+        statsd.distribution("my.test.timestamp.metric", 9, timestamp=123456789.123)
+        self._checkOnlyOneMetric("my.test.timestamp.metric:9|d|T123456789")

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -112,6 +112,34 @@ class TestLambdaMetric(unittest.TestCase):
         self.mock_write_metric_point_to_stdout.assert_not_called()
 
     @patch("datadog_lambda.metric.metrics_handler", MetricsHandler.EXTENSION)
+    def test_lambda_metric_float_with_extension(self):
+        delta = timedelta(minutes=1)
+        timestamp_float = (datetime.now() - delta).timestamp()
+        timestamp_int = int(timestamp_float)
+
+        lambda_metric("test_timestamp", 1, timestamp_float)
+        self.mock_metric_lambda_stats.distribution.assert_has_calls(
+            [
+                call(
+                    "test_timestamp",
+                    1,
+                    timestamp=timestamp_int,
+                    tags=[dd_lambda_layer_tag],
+                )
+            ]
+        )
+        self.mock_write_metric_point_to_stdout.assert_not_called()
+
+    @patch("datadog_lambda.metric.metrics_handler", MetricsHandler.EXTENSION)
+    def test_lambda_metric_timestamp_junk_with_extension(self):
+        delta = timedelta(minutes=1)
+        timestamp = (datetime.now() - delta).isoformat()
+
+        lambda_metric("test_timestamp", 1, timestamp)
+        self.mock_metric_lambda_stats.distribution.assert_not_called()
+        self.mock_write_metric_point_to_stdout.assert_not_called()
+
+    @patch("datadog_lambda.metric.metrics_handler", MetricsHandler.EXTENSION)
     def test_lambda_metric_invalid_timestamp_with_extension(self):
         delta = timedelta(hours=5)
         timestamp = int((datetime.now() - delta).timestamp())


### PR DESCRIPTION
### Testing Guidelines

Added unit tests.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
