### PR TITLE
(feat): Enable Exception Replay in Lambda

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -53,7 +53,9 @@ llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true"
 if llmobs_env_var:
     from ddtrace.llmobs import LLMObs
 
-exception_replay_env_var = os.environ.get("DD_EXCEPTION_REPLAY_ENABLED", "false").lower() in ("true", "1")
+exception_replay_env_var = os.environ.get(
+    "DD_EXCEPTION_REPLAY_ENABLED", "false"
+).lower() in ("true", "1")
 if exception_replay_env_var:
     from ddtrace.debugging._exception.replay import SpanExceptionHandler
 

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -53,6 +53,10 @@ llmobs_env_var = os.environ.get("DD_LLMOBS_ENABLED", "false").lower() in ("true"
 if llmobs_env_var:
     from ddtrace.llmobs import LLMObs
 
+exception_replay_env_var = os.environ.get("DD_EXCEPTION_REPLAY_ENABLED", "false").lower() in ("true", "1")
+if exception_replay_env_var:
+    from ddtrace.debugging._exception.replay import SpanExceptionHandler
+
 logger = logging.getLogger(__name__)
 
 DD_FLUSH_TO_LOG = "DD_FLUSH_TO_LOG"
@@ -223,6 +227,11 @@ class _LambdaDecorator(object):
             # Enable LLM Observability
             if llmobs_env_var:
                 LLMObs.enable()
+
+            # Enable Exception Replay
+            if exception_replay_env_var:
+                logger.debug("Enabling exception replay")
+                SpanExceptionHandler.enable()
 
             logger.debug("datadog_lambda_wrapper initialized")
         except Exception as e:


### PR DESCRIPTION
### What does this PR do?

Enable exception replay in Lambda if `DD_EXCEPTION_REPLAY_ENABLED=true`

[Exception replay blog post](https://www.datadoghq.com/blog/exception-replay-datadog/)

Note: At the moment, this only works when `DD_EXTENSION_VERSION=compatibility`. This is because we have not yet implemented these endpoints in the Rust extension:
- `/debugger/v1/diagnostics`
- `/debugger/v1/input`

### Motivation

Support exception replay in Lambda

### Testing Guidelines

Manually. It works when compatibility mode is enabled:
<img width="800" alt="Screenshot 2025-05-09 at 12 55 52 PM" src="https://github.com/user-attachments/assets/2e9443d3-98c5-4241-8940-99c748586cc1" />

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
