### PR TITLE
fix:  safely getting all the values for trigger tags

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -174,6 +174,7 @@ def parse_event_source(event: dict) -> _EventSource:
 
 
 def detect_lambda_function_url_domain(domain: str) -> bool:
+    #  e.g. "etsn5fibjr.lambda-url.eu-south-1.amazonaws.com"
     if not isinstance(domain, str):
         return False
     domain_parts = domain.split(".")

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -272,6 +272,7 @@ class TestGetEventSourceAndARN(unittest.TestCase):
 
     def test_detect_lambda_function_url_domain_with_invalid_input(self):
         from datadog_lambda.trigger import detect_lambda_function_url_domain
+
         # Test with non-string input
         self.assertFalse(detect_lambda_function_url_domain(None))
         self.assertFalse(detect_lambda_function_url_domain(12345))
@@ -555,18 +556,22 @@ class GetTriggerTags(unittest.TestCase):
 
     def test_extract_http_tags_with_invalid_request_context(self):
         from datadog_lambda.trigger import extract_http_tags
+
         # Test with requestContext as a string instead of a dict
         event = {"requestContext": "not_a_dict", "path": "/test", "httpMethod": "GET"}
         http_tags = extract_http_tags(event)
         # Should still extract valid tags from the event
-        self.assertEqual(http_tags, {"http.url_details.path": "/test", "http.method": "GET"})
+        self.assertEqual(
+            http_tags, {"http.url_details.path": "/test", "http.method": "GET"}
+        )
 
     def test_extract_http_tags_with_invalid_apigateway_http(self):
         from datadog_lambda.trigger import extract_http_tags
+
         # Test with http in requestContext that's not a dict
         event = {
             "requestContext": {"stage": "prod", "http": "not_a_dict"},
-            "version": "2.0"
+            "version": "2.0",
         }
         http_tags = extract_http_tags(event)
         # Should not raise an exception
@@ -574,6 +579,7 @@ class GetTriggerTags(unittest.TestCase):
 
     def test_extract_http_tags_with_invalid_headers(self):
         from datadog_lambda.trigger import extract_http_tags
+
         # Test with headers that's not a dict
         event = {"headers": "not_a_dict"}
         http_tags = extract_http_tags(event)
@@ -582,6 +588,7 @@ class GetTriggerTags(unittest.TestCase):
 
     def test_extract_http_tags_with_invalid_route(self):
         from datadog_lambda.trigger import extract_http_tags
+
         # Test with routeKey that would cause a split error
         event = {"routeKey": 12345}  # Not a string
         http_tags = extract_http_tags(event)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -256,6 +256,29 @@ class TestGetEventSourceAndARN(unittest.TestCase):
         self.assertEqual(event_source.to_string(), "unknown")
         self.assertEqual(event_source_arn, None)
 
+    def test_event_source_with_non_dict_request_context(self):
+        # Test with requestContext as a string instead of a dict
+        event = {"requestContext": "not_a_dict"}
+        event_source = parse_event_source(event)
+        # Should still return a valid event source (unknown in this case)
+        self.assertEqual(event_source.to_string(), "unknown")
+
+    def test_event_source_with_invalid_domain_name(self):
+        # Test with domainName that isn't a string
+        event = {"requestContext": {"stage": "prod", "domainName": 12345}}
+        event_source = parse_event_source(event)
+        # Should detect as API Gateway since stage is present
+        self.assertEqual(event_source.to_string(), "api-gateway")
+
+    def test_detect_lambda_function_url_domain_with_invalid_input(self):
+        from datadog_lambda.trigger import detect_lambda_function_url_domain
+        # Test with non-string input
+        self.assertFalse(detect_lambda_function_url_domain(None))
+        self.assertFalse(detect_lambda_function_url_domain(12345))
+        self.assertFalse(detect_lambda_function_url_domain({"not": "a-string"}))
+        # Test with string that would normally cause an exception when split
+        self.assertFalse(detect_lambda_function_url_domain(""))
+
 
 class GetTriggerTags(unittest.TestCase):
     def test_extract_trigger_tags_api_gateway(self):
@@ -529,6 +552,41 @@ class GetTriggerTags(unittest.TestCase):
         ctx = get_mock_context()
         tags = extract_trigger_tags(event, ctx)
         self.assertEqual(tags, {})
+
+    def test_extract_http_tags_with_invalid_request_context(self):
+        from datadog_lambda.trigger import extract_http_tags
+        # Test with requestContext as a string instead of a dict
+        event = {"requestContext": "not_a_dict", "path": "/test", "httpMethod": "GET"}
+        http_tags = extract_http_tags(event)
+        # Should still extract valid tags from the event
+        self.assertEqual(http_tags, {"http.url_details.path": "/test", "http.method": "GET"})
+
+    def test_extract_http_tags_with_invalid_apigateway_http(self):
+        from datadog_lambda.trigger import extract_http_tags
+        # Test with http in requestContext that's not a dict
+        event = {
+            "requestContext": {"stage": "prod", "http": "not_a_dict"},
+            "version": "2.0"
+        }
+        http_tags = extract_http_tags(event)
+        # Should not raise an exception
+        self.assertEqual(http_tags, {})
+
+    def test_extract_http_tags_with_invalid_headers(self):
+        from datadog_lambda.trigger import extract_http_tags
+        # Test with headers that's not a dict
+        event = {"headers": "not_a_dict"}
+        http_tags = extract_http_tags(event)
+        # Should not raise an exception
+        self.assertEqual(http_tags, {})
+
+    def test_extract_http_tags_with_invalid_route(self):
+        from datadog_lambda.trigger import extract_http_tags
+        # Test with routeKey that would cause a split error
+        event = {"routeKey": 12345}  # Not a string
+        http_tags = extract_http_tags(event)
+        # Should not raise an exception
+        self.assertEqual(http_tags, {})
 
 
 class ExtractHTTPStatusCodeTag(unittest.TestCase):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Make sure we get the `trigger_tags` values safely without raising exceptions. We have some customer's payload that cannot be properly handled currently.

As an alternative, there's a `try-catch-call`[solution](https://github.com/DataDog/datadog-lambda-python/pull/595/files). (Not recommended)
The recommended approach is this PR.

### Motivation

https://datadoghq.atlassian.net/browse/APMSVLS-10
Customer ticket:
https://datadoghq.atlassian.net/browse/SLES-2218

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
