### PR TITLE
a try-catch-all solution

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -330,7 +330,10 @@ def extract_trigger_tags(event: dict, context: Any) -> dict:
     try:
         trigger_tags = {}
         event_source = parse_event_source(event)
-        if event_source.to_string() is not None and event_source.to_string() != "unknown":
+        if (
+            event_source.to_string() is not None
+            and event_source.to_string() != "unknown"
+        ):
             trigger_tags["function_trigger.event_source"] = event_source.to_string()
 
             event_source_arn = get_event_source_arn(event_source, event, context)
@@ -343,6 +346,7 @@ def extract_trigger_tags(event: dict, context: Any) -> dict:
         return trigger_tags
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.info(f"Datadog failed to extract trigger tags: {e}")
         return {}

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -531,7 +531,9 @@ class GetTriggerTags(unittest.TestCase):
         self.assertEqual(tags, {})
 
     def test_extract_trigger_tags_error_handling(self):
-        event = {"requestContext": "not_a_dict"}  # This would cause an error as requestContext is not a dict
+        event = {
+            "requestContext": "not_a_dict"
+        }  # This would cause an error as requestContext is not a dict
         ctx = get_mock_context()
 
         tags = extract_trigger_tags(event, ctx)


### PR DESCRIPTION
Pro:
- Doesn't "swallow" corner cases because it would log it and warn the customers.

Con:
- Most likely the corner cases will end up all using `{}` for trigger_tags. 