### PR TITLE
perf: fewer memory allocation

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -115,9 +115,9 @@ def parse_event_source(event: dict) -> _EventSource:
     event_source = None
 
     # Get requestContext safely and ensure it's a dictionary
-    request_context = event.get("requestContext", {})
+    request_context = event.get("requestContext") or {}
     if not isinstance(request_context, dict):
-        request_context = {}
+        request_context = None
 
     if request_context and request_context.get("stage"):
         if "domainName" in request_context and detect_lambda_function_url_domain(
@@ -291,9 +291,9 @@ def extract_http_tags(event):
     http_tags = {}
 
     # Safely get request_context and ensure it's a dictionary
-    request_context = event.get("requestContext", {})
+    request_context = event.get("requestContext") or {}
     if not isinstance(request_context, dict):
-        request_context = {}
+        request_context = None
 
     path = event.get("path")
     method = event.get("httpMethod")

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -291,7 +291,7 @@ def extract_http_tags(event):
     http_tags = {}
 
     # Safely get request_context and ensure it's a dictionary
-    request_context = event.get("requestContext") or {}
+    request_context = event.get("requestContext")
     if not isinstance(request_context, dict):
         request_context = None
 

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -115,7 +115,7 @@ def parse_event_source(event: dict) -> _EventSource:
     event_source = None
 
     # Get requestContext safely and ensure it's a dictionary
-    request_context = event.get("requestContext") or {}
+    request_context = event.get("requestContext")
     if not isinstance(request_context, dict):
         request_context = None
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Less memory allocation and better performance.

### Explanation
Memory allocation timing:

- d.get("k", {}) always creates a new empty dictionary when the function is called, regardless of whether it will be used
- d.get("k") or {} only creates the empty dictionary if d.get("k") returns a falsy value


Handling of falsy values:

- d.get("k", {}) only uses the default when the key is missing
- d.get("k") or {} uses the empty dict when the key is missing OR when the value exists but is falsy (None, empty string, 0, False, etc.)


Performance implications:

- d.get("k", {}) has a slight overhead of always creating an object that might be discarded
- d.get("k") or {} is slightly more efficient when the key exists with a truthy value

this is a follow-up PR for PR https://github.com/DataDog/datadog-lambda-python/pull/593.
https://datadoghq.atlassian.net/browse/APMSVLS-10

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
