### PR TITLE
fix: call `patch_all` before importing handler code.

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -17,3 +17,10 @@ from datadog_lambda.logger import initialize_logging  # noqa: E402
 
 
 initialize_logging(__name__)
+
+
+from datadog_lambda.patch import patch_all  # noqa: E402
+
+# Patch third-party libraries for tracing, must be done before importing any
+# handler code.
+patch_all()

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -47,6 +47,10 @@ from datadog_lambda.trigger import (
     extract_http_status_code_tag,
 )
 
+# Patch third-party libraries for tracing, must be done before importing any
+# handler code.
+patch_all()
+
 if config.profiling_enabled:
     from ddtrace.profiling import profiler
 
@@ -142,8 +146,6 @@ class _LambdaDecorator(object):
             os.environ[DD_REQUESTS_SERVICE_NAME] = os.environ.get(
                 DD_SERVICE, "aws.lambda"
             )
-            # Patch third-party libraries for tracing
-            patch_all()
 
             # Enable LLM Observability
             if config.llmobs_enabled:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -25,7 +25,6 @@ from datadog_lambda.constants import (
     Headers,
 )
 from datadog_lambda.module_name import modify_module_name
-from datadog_lambda.patch import patch_all
 from datadog_lambda.span_pointers import calculate_span_pointers
 from datadog_lambda.tag_object import tag_object
 from datadog_lambda.tracing import (
@@ -46,10 +45,6 @@ from datadog_lambda.trigger import (
     extract_trigger_tags,
     extract_http_status_code_tag,
 )
-
-# Patch third-party libraries for tracing, must be done before importing any
-# handler code.
-patch_all()
 
 if config.profiling_enabled:
     from ddtrace.profiling import profiler

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -119,7 +119,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -133,7 +133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -145,7 +146,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -160,7 +161,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -326,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -340,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -352,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -367,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -485,7 +489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -499,7 +503,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -511,7 +516,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -526,7 +531,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -660,7 +666,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -674,7 +680,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -686,7 +693,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -701,7 +708,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -826,7 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -840,7 +848,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -852,7 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -867,7 +876,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1001,7 +1011,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1015,7 +1025,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1027,7 +1038,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1042,7 +1053,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1165,7 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1179,7 +1191,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1191,7 +1204,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1206,7 +1219,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1328,7 +1342,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1342,7 +1356,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1354,7 +1369,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1369,7 +1384,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1499,7 +1515,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1513,7 +1529,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1525,7 +1542,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1540,7 +1557,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -99,7 +99,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -113,7 +113,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -125,7 +126,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -140,7 +141,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -158,7 +160,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -174,6 +176,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -325,7 +328,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -339,7 +342,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -351,7 +355,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -366,7 +370,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -384,7 +389,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -400,6 +405,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,7 +509,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -517,7 +523,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -529,7 +536,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -544,7 +551,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -562,7 +570,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -578,6 +586,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -697,7 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -711,7 +720,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -723,7 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -738,7 +748,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -756,7 +767,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -772,6 +783,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -882,7 +894,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -896,7 +908,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -908,7 +921,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -923,7 +936,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -941,7 +955,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -957,6 +971,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1076,7 +1091,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1090,7 +1105,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1102,7 +1118,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1117,7 +1133,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1135,7 +1152,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1151,6 +1168,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1259,7 +1277,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1273,7 +1291,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1285,7 +1304,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1300,7 +1319,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1318,7 +1338,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1334,6 +1354,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1441,7 +1462,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1455,7 +1476,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1467,7 +1489,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1482,7 +1504,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1500,7 +1523,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1516,6 +1539,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1631,7 +1655,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1645,7 +1669,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1657,7 +1682,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "GET /",
         "name": "requests.request",
         "error": 0,
@@ -1672,7 +1697,8 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X"
+          "http.useragent": "python-requests/X.X.X",
+          "_dd.base_service": "integration-tests-python"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1690,7 +1716,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "integration-tests-python",
+        "service": "requests",
         "resource": "POST /api/v1/distribution_points",
         "name": "requests.request",
         "error": 0,
@@ -1706,6 +1732,7 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
+          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -45,10 +45,6 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_inject_correlation_ids = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch("datadog_lambda.wrapper.patch_all")
-        self.mock_patch_all = patcher.start()
-        self.addCleanup(patcher.stop)
-
         patcher = patch("datadog_lambda.tags.get_cold_start_tag")
         self.mock_get_cold_start_tag = patcher.start()
         self.mock_get_cold_start_tag.return_value = "cold_start:true"
@@ -117,7 +113,6 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         )
         self.mock_set_correlation_ids.assert_called()
         self.mock_inject_correlation_ids.assert_called()
-        self.mock_patch_all.assert_called()
 
     def test_datadog_lambda_wrapper_flush_to_log(self):
         os.environ["DD_FLUSH_TO_LOG"] = "True"
@@ -487,7 +482,6 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
 
         lambda_handler_double_wrapped(lambda_event, get_mock_context())
 
-        self.mock_patch_all.assert_called_once()
         self.mock_submit_invocations_metric.assert_called_once()
 
     def test_dd_requests_service_name_default(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Move location of where we call `ddtrace.patch_all`, ensuring it is always called before the handler is imported.

### Motivation

<!--- What inspired you to submit this pull request? --->

Customer reported issue (see https://datadoghq.atlassian.net/browse/SLES-2262) of not seeing spans or distributed tracing from their `confluent_kafka` calls. Here is a highly simplified version of their lambda handler:

```python
from confluent_kafka import Producer

producer = Producer({'bootstrap.servers': 'mybroker1,mybroker2'})

def handle(event, context):
    producer.produce('mytopic', 'hello world!')
    producer.flush()
```

`datadog-lambda` calls `ddtrace.patch_all()` _after_ the customer handler is imported. To see this look at [`handler.py`](./datadog_lambda/handler.py) and [`wrapper.py`](./datadog_lambda/wrapper.py). Here, `patch_all()` is currently called when initializing the `DatadogWrapper` in `wrapper.py`. This only happens _after_ all customer code is imported in `handler.py`. To demonstrate, here's a commented version of a abridged version of our `handler.py` file:

```python
from importlib import import_module

import os
from time import time_ns

from datadog_lambda.tracing import emit_telemetry_on_exception_outside_of_handler
from datadog_lambda.wrapper import datadog_lambda_wrapper			# <--- wrapper imported
from datadog_lambda.module_name import modify_module_name

... other stuff ...

try:
    handler_load_start_time_ns = time_ns()
    handler_module = import_module(modified_mod_name)				# <--- handler cold imported
    handler_func = getattr(handler_module, handler_name)
except Exception as e:
    emit_telemetry_on_exception_outside_of_handler(
        e,
        modified_mod_name,
        handler_load_start_time_ns,
    )
    raise

handler = datadog_lambda_wrapper(handler_func)						# <--- patch_all called
```

The calling of `patch_all()` after their handler code is imported is causing the producer to not get any instrumentation applied. We can see this by inspecting the producer's type.

```python
print(producer.__class__.__name__)  # prints "Producer" but should be "TracedProducer"
```

💭 So wait a minute 💭, why is this only a problem now? This call to `patch_all()` was added over 5 years ago, why has no one reported this until now!?

This has to do with the nature of how ddtrace does it's patching. It's individual to each contrib module patched and how the customer uses it.

Interestingly, if you were to inspect the producer type in a different way, we see a different result:

```python
import confluent_kafka
from confluent_kafka import Producer

print(confluent_kafka.Producer.__name__)  # prints "TracedProducer"
print(Producer.__name__)                  # prints "Producer"
```

Why is this? Because `confluent_kafka.Producer` accesses the producer by reference whereas `Producer` has initialized and saved the producer as the non-traced class.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

⚠️ Important note ⚠️ This PR has the added consequence that customers will now see spans created by patched module calls made on the global level (ie on cold start). Previously these spans were not created at all, because `patch_all()` hadn't been called until _after_ the handler code was fully imported. For example, this code will now produce a span for the requests http call made on the global level during cold start.

```python
import requests

resp = requests.get('https://example.com')
print(resp.status_code)

def handler(event, context):
    pass
```

The only problem is (and here's the ⚠️ warning) that these newly created spans will always be orphaned. This is because of the way in which we manage cold start tracing. During cold start we are unable to determine the trace id because we have not yet started the root trace span nor have we been able to receive any inbound distributed tracing headers.

It should be possible to correctly parent these new orphaned spans. However, that is outside the scope of this PR because it will be difficult and significant undertaking. We can cross that bridge when we get there.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
