### PR TITLE
Fix flushing in Exception Replay

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -58,6 +58,7 @@ exception_replay_env_var = os.environ.get(
 ).lower() in ("true", "1")
 if exception_replay_env_var:
     from ddtrace.debugging._exception.replay import SpanExceptionHandler
+    from ddtrace.debugging._uploader import LogsIntakeUploaderV1
 
 logger = logging.getLogger(__name__)
 
@@ -404,6 +405,10 @@ class _LambdaDecorator(object):
 
             if llmobs_env_var:
                 LLMObs.flush()
+
+            # Flush exception replay
+            if exception_replay_env_var:
+                LogsIntakeUploaderV1._instance.periodic()
 
             if self.encode_authorizer_context and is_authorizer_response(self.response):
                 self._inject_authorizer_span_headers(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

In between Lambdas (after END, before START), all threads are frozen, so queued up tasks cannot run until the next invocation.

Currently, in Python, exception replay for one invocation can only works if another invocation happens in the same execution context. This is because `periodic` (which is the tracer's method for making requests to the Exception Replay endpoint) is queued up but frozen on END, and only fires if another START event is received.

This change just calls the `periodic()` method at the end of the Lambda but before the threads are frozen. This fixes Exception Replay flushing and no longer requires a separate invocation to work.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6845

### Testing Guidelines

Manually - exception replay now works after only one invocation.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
