### PR TITLE
feat: Add dsm support for sns->lambda 

### DIFF
--- a/datadog_lambda/dsm.py
+++ b/datadog_lambda/dsm.py
@@ -3,19 +3,28 @@ from datadog_lambda.trigger import EventTypes
 
 
 def set_dsm_context(event, event_source):
-
     if event_source.equals(EventTypes.SQS):
         _dsm_set_sqs_context(event)
+    elif event_source.equals(EventTypes.SNS):
+        _dsm_set_sns_context(event)
 
 
-def _dsm_set_sqs_context(event):
+def _dsm_set_context_helper(
+    event, service_type, arn_extractor, payload_size_calculator
+):
+    """
+    Common helper function for setting DSM context.
+
+    Args:
+        event: The Lambda event containing records
+        service_type: The service type string (example: sqs', 'sns')
+        arn_extractor: Function to extract the ARN from the record
+        payload_size_calculator: Function to calculate payload size
+    """
     from datadog_lambda.wrapper import format_err_with_traceback
     from ddtrace.internal.datastreams import data_streams_processor
     from ddtrace.internal.datastreams.processor import DsmPathwayCodec
-    from ddtrace.internal.datastreams.botocore import (
-        get_datastreams_context,
-        calculate_sqs_payload_size,
-    )
+    from ddtrace.internal.datastreams.botocore import get_datastreams_context
 
     records = event.get("Records")
     if records is None:
@@ -24,15 +33,41 @@ def _dsm_set_sqs_context(event):
 
     for record in records:
         try:
-            queue_arn = record.get("eventSourceARN", "")
+            arn = arn_extractor(record)
+            context_json = get_datastreams_context(record)
+            payload_size = payload_size_calculator(record, context_json)
 
-            contextjson = get_datastreams_context(record)
-            payload_size = calculate_sqs_payload_size(record)
-
-            ctx = DsmPathwayCodec.decode(contextjson, processor)
+            ctx = DsmPathwayCodec.decode(context_json, processor)
             ctx.set_checkpoint(
-                ["direction:in", f"topic:{queue_arn}", "type:sqs"],
+                ["direction:in", f"topic:{arn}", f"type:{service_type}"],
                 payload_size=payload_size,
             )
         except Exception as e:
             logger.error(format_err_with_traceback(e))
+
+
+def _dsm_set_sns_context(event):
+    from ddtrace.internal.datastreams.botocore import calculate_sns_payload_size
+
+    def sns_payload_calculator(record, context_json):
+        return calculate_sns_payload_size(record, context_json)
+
+    def sns_arn_extractor(record):
+        sns_data = record.get("Sns")
+        if not sns_data:
+            return ""
+        return sns_data.get("TopicArn", "")
+
+    _dsm_set_context_helper(event, "sns", sns_arn_extractor, sns_payload_calculator)
+
+
+def _dsm_set_sqs_context(event):
+    from ddtrace.internal.datastreams.botocore import calculate_sqs_payload_size
+
+    def sqs_payload_calculator(record, context_json):
+        return calculate_sqs_payload_size(record)
+
+    def sqs_arn_extractor(record):
+        return record.get("eventSourceARN", "")
+
+    _dsm_set_context_helper(event, "sqs", sqs_arn_extractor, sqs_payload_calculator)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add support for sns -> lambda in DSM. Actually, SNS->SQS-> lambda was also taken care of as no checkpoints need to 
be set between the queues. So the SQS->lambda PR already solved that

### Motivation

<!--- What inspired you to submit this pull request? --->
Lambdas were broken in DSM

### Testing Guidelines

<!--- How did you test this pull request? --->
Wrote unit tests for added functionality

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
