### PR TITLE
feat: add sns->sqs->lambda support

### DIFF
--- a/datadog_lambda/dsm.py
+++ b/datadog_lambda/dsm.py
@@ -51,6 +51,7 @@ def _dsm_set_kinesis_context(event):
 
 def _set_dsm_context_for_record(record, type, arn):
     from ddtrace.data_streams import set_consume_checkpoint
+
     try:
         context_json = _get_dsm_context_from_lambda(record)
         if not context_json:
@@ -94,7 +95,9 @@ def _get_dsm_context_from_lambda(message):
                 if "MessageAttributes" in parsed_body:
                     message_body = parsed_body
         except (ValueError, TypeError):
-            logger.debug("Unable to parse lambda message body as JSON, treat as non-json")
+            logger.debug(
+                "Unable to parse lambda message body as JSON, treat as non-json"
+            )
 
     message_attributes = message_body.get("MessageAttributes") or message_body.get(
         "messageAttributes"

--- a/datadog_lambda/dsm.py
+++ b/datadog_lambda/dsm.py
@@ -51,7 +51,6 @@ def _dsm_set_kinesis_context(event):
 
 def _set_dsm_context_for_record(record, type, arn):
     from ddtrace.data_streams import set_consume_checkpoint
-
     try:
         context_json = _get_dsm_context_from_lambda(record)
         if not context_json:
@@ -59,7 +58,7 @@ def _set_dsm_context_for_record(record, type, arn):
             return
 
         carrier_get = _create_carrier_get(context_json)
-        set_consume_checkpoint(type, arn, carrier_get, manual_checkpoint=False)
+        set_consume_checkpoint(type, arn, carrier_get)
     except Exception as e:
         logger.error(f"Unable to set dsm context: {e}")
 
@@ -91,7 +90,9 @@ def _get_dsm_context_from_lambda(message):
         try:
             body = message.get("body")
             if body:
-                message_body = json.loads(body)
+                parsed_body = json.loads(body)
+                if "MessageAttributes" in parsed_body:
+                    message_body = parsed_body
         except (ValueError, TypeError):
             logger.debug("Unable to parse lambda message body as JSON, treat as non-json")
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR adds DSM support for sns -> sqs -> lamda, Changing the get_dsm_context() so that context can be properly extracted from the sqs -> lambda step. A checkpoint does not need to be set between queues. 

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Many customers have SNS->SQS architecture, if only support SNS or only support SQS they will think the product is still broken
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Added unit tests
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
