### PR TITLE
feat(appsec): skip processing spans for events that are not http requests

### DIFF
--- a/datadog_lambda/asm.py
+++ b/datadog_lambda/asm.py
@@ -44,6 +44,16 @@ def _merge_single_and_multi_value_headers(
     return _to_single_value_headers(merged_headers)
 
 
+def asm_set_context(event_source: _EventSource):
+    """Add asm specific items to the ExecutionContext.
+
+    This allows the AppSecSpanProcessor to know information about the event
+    at the moment the span is created and skip it when not relevant.
+    """
+    if event_source.event_type not in _http_event_types:
+        core.set_item("appsec_skip_next_lambda_event", True)
+
+
 def asm_start_request(
     span: Span,
     event: Dict[str, Any],

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -9,7 +9,7 @@ import ujson as json
 from importlib import import_module
 from time import time_ns
 
-from datadog_lambda.asm import asm_start_response, asm_start_request
+from datadog_lambda.asm import asm_set_context, asm_start_response, asm_start_request
 from datadog_lambda.dsm import set_dsm_context
 from datadog_lambda.extension import should_use_extension, flush_extension
 from datadog_lambda.cold_start import (
@@ -239,6 +239,10 @@ class _LambdaDecorator(object):
                     )
                 if config.data_streams_enabled:
                     set_dsm_context(event, event_source)
+
+                if config.appsec_enabled:
+                    asm_set_context(event_source)
+
                 self.span = create_function_execution_span(
                     context=context,
                     function_name=config.function_name,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR allows for the AppSecSpanProcessor to skip processing spans for events that are not http requests. The information is propagated through an item on the ExecutionContext.

### Motivation

Spans for unsupported events must not be processed by the AppSecSpanProcessor. To achieve this, the information that the span can be skipped must be available to the AppSecSpanProcessor before the span is started.

### Additional Notes

This PR is tied to:  https://github.com/DataDog/dd-trace-py/pull/13855 

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
