### PR TITLE
build: build layers with latest versions of ddtrace for system-tests to consume

### DIFF
--- a/.github/workflows/build_layer.yml
+++ b/.github/workflows/build_layer.yml
@@ -1,0 +1,35 @@
+name: Build Layers for system-Tests
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Patch pyproject.toml
+        run: |
+          echo "Patching pyproject.toml to use main branch of dd-trace-py"
+          sed -i 's|^ddtrace =.*$|ddtrace = { git = "https://github.com/DataDog/dd-trace-py.git" }|' pyproject.toml
+
+      - name: Build layer for Python ${{ matrix.python_version }} on ${{ matrix.arch }}
+        run: |
+          echo "Building layer for Python ${{ matrix.python_version }} on ${{ matrix.arch }}"
+          ARCH=${{ matrix.arch }} PYTHON_VERSION=${{ matrix.python_version }} ./scripts/build_layers.sh
+
+      - name: Upload layer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: .layers/datadog_lambda_py-${{ matrix.arch }}-${{ matrix.python_version }}.zip
+          name: datadog-lambda-python-${{ matrix.python_version }}-${{ matrix.arch }}


### PR DESCRIPTION
### What does this PR do?

This PR adds a github workflow to build layers on each update on the `main` branch. It uses the `main` branch of `dd-trace-py` as well to really provide the `latest` dev version available.

Note: the job takes around 7m (building ddtrace takes the majority of the time)

### Motivation

The goal is to have artifacts for up-to-date development version of the layers for the [system-tests](https://github.com/DataDog/system-tests.git) to consume easily.

This allows the system-tests repo to just fetch a layer without needing any knowledge on how to build layers.

### Testing Guidelines

I tested this workflow on my development branch. You can find the execution here: https://github.com/DataDog/datadog-lambda-python/actions/runs/16189728626

### Additional Notes

This PR adds a build matrix for every combination of architecture and python version. I don't aim on running system-tests for all of them.
On the one hand I find it practical to have all variants available in the same place and since they all built in parallel adding more combinations doesn't make the CI longer. On the other hand, It also makes sense to just build what is going to be used. I can remove some targets if you think this is too much.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
