### PR TITLE
Enhance Synthetic Span Service Representation

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -863,7 +863,8 @@ def determine_service_name(
     service_name = service_mapping.get(specific_key)
     if service_name is None:
         service_name = service_mapping.get(
-            generic_key, default_value if default_value is not None else fallback,
+            generic_key,
+            default_value if default_value is not None else fallback,
         )
     return service_name
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -861,17 +861,23 @@ def determine_service_name(
     service_mapping, specific_key, generic_key, extracted_key, fallback=None
 ):
     # Check for mapped service (specific key first, then generic key)
-    mapped_service = service_mapping.get(specific_key) or service_mapping.get(generic_key)
+    mapped_service = service_mapping.get(specific_key) or service_mapping.get(
+        generic_key
+    )
     if mapped_service:
         return mapped_service
-    
+
     # Check if AWS service representation is disabled
-    aws_service_representation = os.environ.get("DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED", "").lower()
+    aws_service_representation = os.environ.get(
+        "DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED", ""
+    ).lower()
     if aws_service_representation in ("false", "0"):
         return fallback
-    
+
     # Use extracted_key if it exists and is not empty, otherwise use fallback
-    return extracted_key.strip() if extracted_key and extracted_key.strip() else fallback
+    return (
+        extracted_key.strip() if extracted_key and extracted_key.strip() else fallback
+    )
 
 
 # Initialization code
@@ -1452,12 +1458,14 @@ def create_function_execution_span(
     if config.service:
         service_name = config.service
     else:
-        aws_service_representation = os.environ.get("DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED", "").lower()
+        aws_service_representation = os.environ.get(
+            "DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED", ""
+        ).lower()
         if aws_service_representation in ("false", "0"):
             service_name = "aws.lambda"
         else:
             service_name = function_name if function_name else "aws.lambda"
-    
+
     span = tracer.trace(
         "aws.lambda",
         service=service_name,

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -857,15 +857,14 @@ def create_service_mapping(val):
     return new_service_mapping
 
 
-def determine_service_name(service_mapping,
-                           specific_key,
-                           generic_key,
-                           default_value,
-                           fallback=None):
+def determine_service_name(
+    service_mapping, specific_key, generic_key, default_value, fallback=None
+):
     service_name = service_mapping.get(specific_key)
     if service_name is None:
-        service_name = service_mapping.get(generic_key,
-                                           default_value if default_value is not None else fallback)
+        service_name = service_mapping.get(
+            generic_key, default_value if default_value is not None else fallback,
+        )
     return service_name
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 python = ">=3.8.0,<4"
 datadog = ">=0.51.0,<1.0.0"
 wrapt = "^1.11.2"
-ddtrace = ">=3.10.2,<4"
+ddtrace = ">=3.11.0,<4"
 ujson = ">=5.9.0"
 botocore = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }

--- a/tests/event_samples/kinesisStream.json
+++ b/tests/event_samples/kinesisStream.json
@@ -1,0 +1,20 @@
+{
+    "Records": [
+        {
+            "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "partitionkey",
+                "sequenceNumber": "49624230154685806402418173680709770494154422022871973922",
+                "data": "eyJmb28iOiAiYmFyIiwgIl9kYXRhZG9nIjogeyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiAiNDk0ODM3NzMxNjM1NzI5MTQyMSIsICJ4LWRhdGFkb2ctcGFyZW50LWlkIjogIjI4NzYyNTMzODAwMTg2ODEwMjYiLCAieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjogIjEifX0=",
+                "approximateArrivalTimestamp": 1643638425.163
+            },
+            "eventSource": "aws:kinesis",
+            "eventVersion": "1.0",
+            "eventID": "shardId-000000000002:49624230154685806402418173680709770494154422022871973922",
+            "eventName": "aws:kinesis:record",
+            "invokeIdentityArn": "arn:aws:iam::601427279990:role/inferred-spans-python-dev-eu-west-1-lambdaRole",
+            "awsRegion": "eu-west-1",
+            "eventSourceARN": "arn:aws:kinesis:eu-west-1:601427279990:stream/kinesisStream"
+        }
+    ]
+}

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -59,6 +59,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -84,7 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -107,8 +108,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -428,7 +428,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -439,6 +439,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -460,7 +461,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -477,8 +478,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -631,7 +631,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -654,8 +654,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -766,7 +765,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -777,6 +776,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -804,7 +804,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -822,8 +822,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -934,7 +933,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -943,6 +942,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -981,7 +981,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -999,8 +999,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1111,7 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1122,6 +1121,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1147,7 +1147,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1165,8 +1165,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1277,7 +1276,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1288,6 +1287,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1312,7 +1312,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1330,8 +1330,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1455,6 +1454,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1483,7 +1483,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-async-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1503,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -69,7 +69,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -133,8 +132,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -161,8 +159,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -251,7 +248,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +338,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +365,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -445,7 +439,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -503,8 +496,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -531,8 +523,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -615,7 +606,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -679,8 +669,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -707,8 +696,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -788,7 +776,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -847,8 +834,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -875,8 +861,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -953,7 +938,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1024,8 +1008,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1052,8 +1035,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1131,7 +1113,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1190,8 +1171,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1218,8 +1198,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1296,7 +1275,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1355,8 +1333,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1383,8 +1360,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1467,7 +1443,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1528,8 +1503,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1556,8 +1530,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python310",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python311",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python312",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python313",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python38",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -39,6 +39,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "Prod",
@@ -64,7 +65,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -87,8 +88,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
           "http.route": "/",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -228,7 +228,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "dynamodb",
+        "service": "ExampleTableWithStream",
         "resource": "ExampleTableWithStream",
         "name": "aws.dynamodb",
         "error": 0,
@@ -239,6 +239,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.dynamodb",
           "resource_names": "ExampleTableWithStream",
+          "span.kind": "server",
           "tablename": "ExampleTableWithStream",
           "event_source_arn": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "event_id": "XXXX",
@@ -298,7 +299,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -316,8 +317,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "dynamodb",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -448,7 +448,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "eventbridge",
+        "service": "eventbridge.custom.event.sender",
         "resource": "eventbridge.custom.event.sender",
         "name": "aws.eventbridge",
         "error": 0,
@@ -459,6 +459,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.eventbridge",
           "resource_names": "eventbridge.custom.event.sender",
+          "span.kind": "server",
           "detail_type": "testdetail",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
@@ -480,7 +481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -497,8 +498,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "datadog_lambda": "X.X.X",
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
-          "function_trigger.event_source": "eventbridge",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source": "eventbridge"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -671,7 +671,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -694,8 +694,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -826,7 +825,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "kinesis",
+        "service": "EXAMPLE",
         "resource": "EXAMPLE",
         "name": "aws.kinesis",
         "error": 0,
@@ -837,6 +836,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.kinesis",
           "resource_names": "EXAMPLE",
+          "span.kind": "server",
           "streamname": "EXAMPLE",
           "shardid": "shardId-XXXX",
           "event_source_arn": "arn:aws:kinesis:EXAMPLE",
@@ -864,7 +864,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -882,8 +882,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "kinesis",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1014,7 +1013,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "s3",
+        "service": "example-bucket",
         "resource": "example-bucket",
         "name": "aws.s3",
         "error": 0,
@@ -1023,6 +1022,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.s3",
           "resource_names": "example-bucket",
+          "span.kind": "server",
           "event_name": "ObjectCreated:Put",
           "bucketname": "example-bucket",
           "bucket_arn": "arn:aws:s3:::example-bucket",
@@ -1061,7 +1061,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1079,8 +1079,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "s3",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1211,7 +1210,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sns",
+        "service": "sns-lambda",
         "resource": "sns-lambda",
         "name": "aws.sns",
         "error": 0,
@@ -1222,6 +1221,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sns",
           "resource_names": "sns-lambda",
+          "span.kind": "server",
           "topicname": "sns-lambda",
           "topic_arn": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "message_id": "XXXX",
@@ -1247,7 +1247,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1265,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sns",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1397,7 +1396,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "sqs",
+        "service": "my-queue",
         "resource": "my-queue",
         "name": "aws.sqs",
         "error": 0,
@@ -1408,6 +1407,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_dd.origin": "lambda",
           "operation_name": "aws.sqs",
           "resource_names": "my-queue",
+          "span.kind": "server",
           "queuename": "my-queue",
           "event_source_arn": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "receipt_handle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
@@ -1432,7 +1432,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1450,8 +1450,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "dd_trace": "X.X.X",
           "span.name": "aws.lambda",
           "function_trigger.event_source": "sqs",
-          "function_trigger.event_source_arn": "XXXX",
-          "_dd.base_service": "integration-tests-python"
+          "function_trigger.event_source_arn": "XXXX"
         },
         "metrics": {
           "_dd.top_level": 1
@@ -1595,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com$default",
           "endpoint": "$default",
           "resource_names": "$default",
+          "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
           "stage": "dev",
@@ -1623,7 +1623,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "trace_id": "XXXX",
         "parent_id": "XXXX",
         "span_id": "XXXX",
-        "service": "aws.lambda",
+        "service": "integration-tests-python",
         "resource": "integration-tests-python-XXXX-sync-metrics_python39",
         "name": "aws.lambda",
         "error": 0,
@@ -1643,8 +1643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.status_code": "200",
-          "_dd.base_service": "integration-tests-python"
+          "http.status_code": "200"
         },
         "metrics": {
           "_dd.top_level": 1

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -49,7 +49,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -113,8 +112,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -141,8 +139,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -176,7 +173,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -251,7 +247,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -342,8 +337,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -370,8 +364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -405,7 +398,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -465,7 +457,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -523,8 +514,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -551,8 +541,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -586,7 +575,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -655,7 +643,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -719,8 +706,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -747,8 +733,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -782,7 +767,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -848,7 +832,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -907,8 +890,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -935,8 +917,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -970,7 +951,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1033,7 +1013,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1104,8 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1132,8 +1110,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1167,7 +1144,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1231,7 +1207,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1290,8 +1265,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1318,8 +1292,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1353,7 +1326,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1416,7 +1388,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1475,8 +1446,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1503,8 +1473,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1538,7 +1507,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1607,7 +1575,6 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.status_code": "200",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"
@@ -1668,8 +1635,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://datadoghq.com/",
           "out.host": "datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1,
@@ -1696,8 +1662,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "http.url": "https://www.datadoghq.com/",
           "out.host": "www.datadoghq.com",
           "http.status_code": "200",
-          "http.useragent": "python-requests/X.X.X",
-          "_dd.base_service": "integration-tests-python"
+          "http.useragent": "python-requests/X.X.X"
         },
         "metrics": {
           "_dd.measured": 1
@@ -1731,7 +1696,6 @@ HTTP POST https://api.datadoghq.com/api/v1/distribution_points Headers: ["Accept
           "out.host": "api.datadoghq.com",
           "http.status_code": "202",
           "http.useragent": "datadogpy/XX (python XX; os linux; arch XXXX)",
-          "_dd.base_service": "integration-tests-python",
           "_dd.p.dm": "-0",
           "_dd.p.tid": "XXXX",
           "language": "python"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1478,7 +1478,7 @@ class TestServiceMapping(unittest.TestCase):
         ] = "arn:aws:sqs:eu-west-1:123456789012:different-sqs-url"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.sqs")
-        self.assertEqual(span2.service, "sqs")
+        self.assertEqual(span2.service, "different-sqs-url")
 
     def test_remaps_all_inferred_span_service_names_from_sns_event(self):
         self.set_service_mapping({"lambda_sns": "new-name"})
@@ -1524,7 +1524,7 @@ class TestServiceMapping(unittest.TestCase):
         ] = "arn:aws:sns:us-west-2:123456789012:different-sns-topic"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.sns")
-        self.assertEqual(span2.service, "sns")
+        self.assertEqual(span2.service, "different-sns-topic")
 
     def test_remaps_all_inferred_span_service_names_from_kinesis_event(self):
         self.set_service_mapping({"lambda_kinesis": "new-name"})
@@ -1561,7 +1561,7 @@ class TestServiceMapping(unittest.TestCase):
 
         span1 = create_inferred_span(original_event, ctx)
         self.assertEqual(span1.get_tag("operation_name"), "aws.kinesis")
-        self.assertEqual(span1.service, "kinesis")
+        self.assertEqual(span1.service, "kinesisStream")
 
         # Testing the second event
         event2 = copy.deepcopy(original_event)
@@ -1570,7 +1570,7 @@ class TestServiceMapping(unittest.TestCase):
         ] = "arn:aws:kinesis:eu-west-1:601427279990:stream/DifferentKinesisStream"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.kinesis")
-        self.assertEqual(span2.service, "kinesis")
+        self.assertEqual(span2.service, "DifferentKinesisStream")
 
     def test_remaps_all_inferred_span_service_names_from_s3_event(self):
         self.set_service_mapping({"lambda_s3": "new-name"})
@@ -1614,7 +1614,7 @@ class TestServiceMapping(unittest.TestCase):
         event2["Records"][0]["s3"]["bucket"]["name"] = "different-example-bucket"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.s3")
-        self.assertEqual(span2.service, "s3")
+        self.assertEqual(span2.service, "different-example-bucket")
 
     def test_remaps_all_inferred_span_service_names_from_dynamodb_event(self):
         self.set_service_mapping({"lambda_dynamodb": "new-name"})
@@ -1660,7 +1660,7 @@ class TestServiceMapping(unittest.TestCase):
         ] = "arn:aws:dynamodb:us-east-1:123456789012:table/DifferentExampleTableWithStream/stream/2015-06-27T00:48:05.899"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.dynamodb")
-        self.assertEqual(span2.service, "dynamodb")
+        self.assertEqual(span2.service, "DifferentExampleTableWithStream")
 
     def test_remaps_all_inferred_span_service_names_from_eventbridge_event(self):
         self.set_service_mapping({"lambda_eventbridge": "new-name"})
@@ -1704,7 +1704,7 @@ class TestServiceMapping(unittest.TestCase):
         event2["source"] = "different.eventbridge.custom.event.sender"
         span2 = create_inferred_span(event2, ctx)
         self.assertEqual(span2.get_tag("operation_name"), "aws.eventbridge")
-        self.assertEqual(span2.service, "eventbridge")
+        self.assertEqual(span2.service, "different.eventbridge.custom.event.sender")
 
 
 class _Span(object):
@@ -1927,7 +1927,7 @@ _test_create_inferred_span = (
     (
         "sqs-string-msg-attribute",
         _Span(
-            service="sqs",
+            service="InferredSpansQueueNode",
             start=1634662094.538,
             span_type="web",
             tags={
@@ -1945,7 +1945,7 @@ _test_create_inferred_span = (
     (
         "sns-string-msg-attribute",
         _Span(
-            service="sns",
+            service="serverlessTracingTopicPy",
             start=1643638421.637,
             span_type="web",
             tags={
@@ -1964,7 +1964,7 @@ _test_create_inferred_span = (
     (
         "sns-b64-msg-attribute",
         _Span(
-            service="sns",
+            service="serverlessTracingTopicPy",
             start=1643638421.637,
             span_type="web",
             tags={
@@ -1981,9 +1981,9 @@ _test_create_inferred_span = (
         ),
     ),
     (
-        "kinesis",
+        "kinesisStream",
         _Span(
-            service="kinesis",
+            service="kinesisStream",
             start=1643638425.163,
             span_type="web",
             tags={
@@ -2000,16 +2000,16 @@ _test_create_inferred_span = (
                 "operation_name": "aws.kinesis",
                 "partition_key": "partitionkey",
                 "request_id": None,
-                "resource_names": "stream/kinesisStream",
+                "resource_names": "kinesisStream",
                 "shardid": "shardId-000000000002",
-                "streamname": "stream/kinesisStream",
+                "streamname": "kinesisStream",
             },
         ),
     ),
     (
         "dynamodb",
         _Span(
-            service="dynamodb",
+            service="ExampleTableWithStream",
             start=1428537600.0,
             span_type="web",
             tags={
@@ -2035,7 +2035,7 @@ _test_create_inferred_span = (
     (
         "s3",
         _Span(
-            service="s3",
+            service="example-bucket",
             start=0.0,
             span_type="web",
             tags={
@@ -2060,7 +2060,7 @@ _test_create_inferred_span = (
     (
         "eventbridge-custom",
         _Span(
-            service="eventbridge",
+            service="eventbridge.custom.event.sender",
             start=1635989865.0,
             span_type="web",
             tags={
@@ -2079,7 +2079,7 @@ _test_create_inferred_span = (
     (
         "eventbridge-sqs",
         _Span(
-            service="sqs",
+            service="eventbridge-sqs-queue",
             start=1691102943.638,
             span_type="web",
             parent_name="aws.eventbridge",

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1283,7 +1283,7 @@ class TestServiceMapping(unittest.TestCase):
             ),
             "default",
         )
-        
+
         # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED set to false
         os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"] = "false"
         self.assertEqual(
@@ -1292,7 +1292,7 @@ class TestServiceMapping(unittest.TestCase):
             ),
             "fallback",
         )
-        
+
         # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED set to 0
         os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"] = "0"
         self.assertEqual(
@@ -1301,7 +1301,7 @@ class TestServiceMapping(unittest.TestCase):
             ),
             "fallback",
         )
-        
+
         # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED not set (default behavior)
         if "DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED" in os.environ:
             del os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"]
@@ -1311,7 +1311,7 @@ class TestServiceMapping(unittest.TestCase):
             ),
             "extracted",
         )
-        
+
         # Test with empty extracted key
         self.assertEqual(
             determine_service_name(

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1283,6 +1283,42 @@ class TestServiceMapping(unittest.TestCase):
             ),
             "default",
         )
+        
+        # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED set to false
+        os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"] = "false"
+        self.assertEqual(
+            determine_service_name(
+                self.get_service_mapping(), "api4", "api4", "extracted", "fallback"
+            ),
+            "fallback",
+        )
+        
+        # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED set to 0
+        os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"] = "0"
+        self.assertEqual(
+            determine_service_name(
+                self.get_service_mapping(), "api4", "api4", "extracted", "fallback"
+            ),
+            "fallback",
+        )
+        
+        # Test with DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED not set (default behavior)
+        if "DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED" in os.environ:
+            del os.environ["DD_TRACE_AWS_SERVICE_REPRESENTATION_ENABLED"]
+        self.assertEqual(
+            determine_service_name(
+                self.get_service_mapping(), "api4", "api4", "extracted", "fallback"
+            ),
+            "extracted",
+        )
+        
+        # Test with empty extracted key
+        self.assertEqual(
+            determine_service_name(
+                self.get_service_mapping(), "api4", "api4", "  ", "fallback"
+            ),
+            "fallback",
+        )
 
         del os.environ["DD_SERVICE_MAPPING"]
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
<!--- A brief description of the change being made with this pull request. --->

Rollout of span naming changes to align serverless product with tracer to create streamlined Service Representation for Serverless

Key Changes:

- Change service name to match instance name for all managed services (aws.lambda -> lambda name, etc) (breaking)

- Add `span.kind:server` on synthetic spans made via span-inferrer

- Implement `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` (default true) to allow users to opt out

### Motivation

<!--- What inspired you to submit this pull request? --->

Improve Service Map for Serverless. This allows for synthetic spans to have their own service on the map which connects with the inferred spans from the tracer side.

### Testing Guidelines

<!--- How did you test this pull request? --->
Unit and Integration tests updated accordingly.

Matching the service name to the instance name essentially removes the need for a base_service tag in some instances due to essentially removing service overrides


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
