### PR TITLE
fix(appsec): enable SpanProcessor through the ddtrace product interface

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -53,6 +53,9 @@ if config.appsec_enabled:
         asm_start_request,
         get_asm_blocked_response,
     )
+    from ddtrace.internal.appsec.product import start
+
+    start()
 
 if config.profiling_enabled:
     from ddtrace.profiling import profiler


### PR DESCRIPTION
### What does this PR do?

This PR enables the AppSec `Product` when `DD_APPSEC_ENABLED` is set.

### Motivation
With https://github.com/DataDog/dd-trace-py/commit/7bfeeb0afb17d886fff0f0cd119c2fb2ad5161f7 (to be released in 3.12), Appsec has moved from being enabled by default by the tracer to being enabled through a `Product`.

Outside of lambda (when started with `ddtrace-run` or `import ddtrace.auto`) products are automatically gathered by a `ProductManager` and started based on the configuration.

This step does not happen in lambda and individual products that we want to make available to lambda need to be started manually. This is what I am doing for Appsec.

### Testing Guidelines

Manually. I don't see how I could test this in unit tests. Suggestions welcome.
It will eventually be caught by system-tests once this PR is ready: https://github.com/DataDog/system-tests/pull/4891

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
