### PR TITLE
Increase allowed layer package size.

### DIFF
--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -8,8 +8,8 @@
 # Compares layer size to threshold, and fails if below that threshold
 
 set -e
-MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 8 \* 1024)
-MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 21 \* 1024)
+MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 17 \* 1024 / 2)  # 8704 KB
+MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 23 \* 1024)   # 23552 KB
 
 
 LAYER_FILES_PREFIX="datadog_lambda_py"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

ddtrace v3.12.0 brought us over the limit. We increased the limit to 23*1024 in serverless tools, we should do the same here.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
