### PR TITLE
build: use lambda image to ensure binary compatibility when building from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,14 @@ ARG runtime
 RUN mkdir -p /build/python/lib/$runtime/site-packages
 WORKDIR /build
 
-# Install GCC
+# Install newer version of GCC on AL2
 RUN set -eux; \
-    if command -v dnf >/dev/null 2>&1; then \
-      dnf -y install git gcc-c++; \
-    else \
+    if command -v yum >/dev/null 2>&1; then \
       yum -y install git gcc10 gcc10-c++; \
-      ln -s /usr/bin/gcc10-gcc /usr/bin/gcc; \
-      ln -s /usr/bin/gcc10-g++ /usr/bin/g++; \
-      ln -s /usr/bin/gcc10-cc /usr/bin/cc; \
+      cd /usr/bin; \
+      rm gcc && ln -s gcc10-gcc gcc; \
+      rm g++ && ln -s gcc10-g++ g++; \
+      rm cc && ln -s gcc10-cc cc; \
     fi
 
 # Add Rust compiler which is needed to build dd-trace-py from source

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -61,7 +61,7 @@ function docker_build_zip {
     # between different python runtimes.
     temp_dir=$(mktemp -d)
     docker buildx build -t datadog-lambda-python-${arch}:$1 . --no-cache \
-        --build-arg image=public.ecr.aws/lambda/python:$1 \
+        --build-arg image=public.ecr.aws/sam/build-python$1:1 \
         --build-arg runtime=python$1 \
         --platform linux/${arch} \
         --progress=plain \


### PR DESCRIPTION
### What does this PR do?

This PR changes the base image for the layer creation process.

Instead of using the generic python image (`docker/library/python` based on debian), I suggest using the lambda python image (`lambda/python` based on AL2 or AL2023 depending on python3 version).

### Motivation

`ddtrace` contains native dependencies which enforce a minimal version of glibc set by the version found at build time.
This means that the glibc version of the build image must be the same as (or older than) the glibc version of the runtime image.

When pushing wheels to `PyPi`, the `dd-trace-py` compiles native dependencies for the `manylinux2014` target which uses an old version of glibc (2.17).

With the release of Debian Trixie last week, all python have now a newer version of glibc than Amazon Linux 2023 (2.34) and executing a function with a layer built from source for python3.13 yields the following error
```log
 Runtime.ImportModuleError: Unable to import module 'datadog_lambda.handler': /lib64/libc.so.6: version `GLIBC_2.38' not found (required by /opt/python/lib/python3.13/site-packages/ddtrace/internal/native/_native.cpython-313-x86_64-linux-gnu.so)
 ``` 
 
 By building on the same image used by the runtime, we ensure the binary compatibility.

### Testing Guidelines

All builds in the CI and snapshot tests pass.

### Additional Notes

This is a blocker for the enabling system-tests for lambda: https://github.com/DataDog/system-tests/actions/runs/17033940078/job/48282245449?pr=4891#step:91:105

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
