### PR TITLE
chore(build): strip debug symbols using `strip -g`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV DD_COMPILE_MODE=Release
 
 # Install datadog_lambda and dependencies from local
 COPY . .
-RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
+RUN pip install -v --no-cache-dir . -t ./python/lib/$runtime/site-packages
 
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
+ENV DD_COMPILE_MODE=Release
+
 # Install datadog_lambda and dependencies from local
 COPY . .
 RUN DD_COMPILE_MODE=Release pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,6 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-# Compile mode is explicitly set here to not build native extensions with
-# debug symbols. Otherwise, they will have debug symbols by default when built
-# from sources. PyPI packages are stripped off of debug symbols, using strip -g.
-# This is mainly to reduce the layer size at the cost of debuggability.
-ENV DD_COMPILE_MODE=Release
-
 # Install datadog_lambda and dependencies from local
 COPY . .
 RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-ENV DD_COMPILE_MODE="Release"
+ENV DD_COMPILE_MODE=Release
 
 # Install datadog_lambda and dependencies from local
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
+# Compile mode is explicitly set here to strip the debug symbols from the
+# native extensions in dd-trace-py. Otherwise, they will have debug symbols
+# by default when built from sources. PyPI packages are stripped off of debug
+# symbols. This is mainly to reduce the layer size at the cost of debuggability
 ENV DD_COMPILE_MODE=Release
 
 # Install datadog_lambda and dependencies from local

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
+ENV DD_COMPILE_MODE="Release"
+
 # Install datadog_lambda and dependencies from local
 COPY . .
 RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV DD_COMPILE_MODE=Release
 
 # Install datadog_lambda and dependencies from local
 COPY . .
-RUN pip install -v --no-cache-dir . -t ./python/lib/$runtime/site-packages
+RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
 
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN curl https://sh.rustup.rs -sSf | \
 ENV PATH=/root/.cargo/bin:$PATH
 
 ENV DD_COMPILE_MODE=Release
+RUN echo "DD_COMPILE_MODE=$DD_COMPILE_MODE"
 
 # Install datadog_lambda and dependencies from local
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV DD_COMPILE_MODE=Release
 
 # Install datadog_lambda and dependencies from local
 COPY . .
-RUN DD_COMPILE_MODE=Release pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
+RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
 
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,9 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-ENV DD_COMPILE_MODE=Release
-RUN echo "DD_COMPILE_MODE=$DD_COMPILE_MODE"
-
 # Install datadog_lambda and dependencies from local
 COPY . .
-RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
+RUN DD_COMPILE_MODE=Release pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
 
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,5 +78,8 @@ RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.h -delete
 RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.hpp -delete
 RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.pyx -delete
 
+# Strip debug symbols using strip -g for all .so files in ddtrace
+RUN find ./python/lib/$runtime/site-packages/ddtrace -name "*.so" -exec strip -g {} \;
+
 FROM scratch
 COPY --from=builder /build/python /


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Run `strip -g` on all .so files in ddtrace to make sure that they're stripped of debug symbols to reduce the layer size. 

This is needed to unblock https://github.com/DataDog/dd-trace-py/pull/14286, which aims to build dd-trace-py with debug symbols by default. 

The more right thing to do would be using pre-built wheel always instead of building from sources.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
