### PR TITLE
Re-remove more iast .so files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN pip install --no-cache-dir . -t ./python/lib/$runtime/site-packages
 RUN rm -rf ./python/lib/$runtime/site-packages/botocore*
 RUN rm -rf ./python/lib/$runtime/site-packages/setuptools
 RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests
+RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_ast/iastpatch*.so
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_taint_tracking/*.so
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
 # _stack_v2 may not exist for some versions of ddtrace (e.g. under python 3.13)


### PR DESCRIPTION
APPSEC-58746

PR https://github.com/DataDog/dd-trace-py/pull/12774 was merged to address this.

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Re-removes the `ddtrace/appsec/_iast/_ast/iastpatch*.so` file from the python layers.

### Motivation

A change was made by the appsec team to the python tracer which inadvertently caused an import attempt on `ddtrace/appsec/_iast/_stacktrace*.so`. This import would fail when using our python layer. We remove this file because it is large and iast doesn't work in serverless anyway.


### Testing Guidelines

<!--- How did you test this pull request? --->

I have another PR open to the python agent (TODO) which will add explicit testing to ensure none of our removed files get imported.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Note that the mentioned PR is merged but not yet released! Do not merge this until that PR has been released!

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
