### PR TITLE
[APPSEC]: fix Lambda not appearing on the Appsec API Security Endpoint Catalog

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -8,8 +8,6 @@ if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED") is None:
         "DD_APPSEC_ENABLED", "false"
     )
 
-if os.environ.get("DD_API_SECURITY_ENABLED") is None:
-    os.environ["DD_API_SECURITY_ENABLED"] = "False"
 
 initialize_cold_start_tracing()
 

--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -288,7 +288,7 @@ def extract_http_tags(event):
     """
     Extracts HTTP facet tags from the triggering event
     """
-    http_tags = {}
+    http_tags = {"span.kind": "server"}
 
     # Safely get request_context and ensure it's a dictionary
     request_context = event.get("requestContext")

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -104,6 +104,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -642,6 +643,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1479,6 +1481,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -84,6 +84,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
           "http.url_details.path": "/Prod/",
           "http.method": "GET",
@@ -679,6 +680,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.url_details.path": "/httpapi/get",
           "http.method": "GET",
@@ -1611,6 +1613,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "span.name": "aws.lambda",
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
+          "span.kind": "server",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
           "http.status_code": "200"
         },

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -305,6 +305,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url_details.path": "/prod/path/to/resource",
                 "http.method": "POST",
                 "http.route": "/{proxy+}",
+                "span.kind": "server",
             },
         )
 
@@ -324,6 +325,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url_details.path": "/dev/http/get",
                 "http.method": "GET",
                 "http.route": "/http/get",
+                "span.kind": "server",
             },
         )
 
@@ -340,6 +342,7 @@ class GetTriggerTags(unittest.TestCase):
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/p62c47itsb/stages/dev",
                 "http.url": "https://p62c47itsb.execute-api.eu-west-1.amazonaws.com",
+                "span.kind": "server",
             },
         )
 
@@ -356,6 +359,7 @@ class GetTriggerTags(unittest.TestCase):
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/p62c47itsb/stages/dev",
                 "http.url": "https://p62c47itsb.execute-api.eu-west-1.amazonaws.com",
+                "span.kind": "server",
             },
         )
 
@@ -372,6 +376,7 @@ class GetTriggerTags(unittest.TestCase):
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/p62c47itsb/stages/dev",
                 "http.url": "https://p62c47itsb.execute-api.eu-west-1.amazonaws.com",
+                "span.kind": "server",
             },
         )
 
@@ -390,6 +395,7 @@ class GetTriggerTags(unittest.TestCase):
                 "http.url": "https://x02yirxc7a.execute-api.eu-west-1.amazonaws.com",
                 "http.url_details.path": "/httpapi/get",
                 "http.method": "GET",
+                "span.kind": "server",
                 "http.route": "/httpapi/get",
             },
         )
@@ -408,6 +414,7 @@ class GetTriggerTags(unittest.TestCase):
                 "function_trigger.event_source_arn": "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-xyz/123abc",
                 "http.url_details.path": "/lambda",
                 "http.method": "GET",
+                "span.kind": "server",
             },
         )
 
@@ -569,7 +576,12 @@ class GetTriggerTags(unittest.TestCase):
         http_tags = extract_http_tags(event)
         # Should still extract valid tags from the event
         self.assertEqual(
-            http_tags, {"http.url_details.path": "/test", "http.method": "GET"}
+            http_tags,
+            {
+                "span.kind": "server",
+                "http.url_details.path": "/test",
+                "http.method": "GET",
+            },
         )
 
     def test_extract_http_tags_with_invalid_apigateway_http(self):
@@ -582,7 +594,7 @@ class GetTriggerTags(unittest.TestCase):
         }
         http_tags = extract_http_tags(event)
         # Should not raise an exception
-        self.assertEqual(http_tags, {})
+        self.assertEqual(http_tags, {"span.kind": "server"})
 
     def test_extract_http_tags_with_invalid_headers(self):
         from datadog_lambda.trigger import extract_http_tags
@@ -591,7 +603,7 @@ class GetTriggerTags(unittest.TestCase):
         event = {"headers": "not_a_dict"}
         http_tags = extract_http_tags(event)
         # Should not raise an exception
-        self.assertEqual(http_tags, {})
+        self.assertEqual(http_tags, {"span.kind": "server"})
 
     def test_extract_http_tags_with_invalid_route(self):
         from datadog_lambda.trigger import extract_http_tags
@@ -600,7 +612,7 @@ class GetTriggerTags(unittest.TestCase):
         event = {"routeKey": 12345}  # Not a string
         http_tags = extract_http_tags(event)
         # Should not raise an exception
-        self.assertEqual(http_tags, {})
+        self.assertEqual(http_tags, {"span.kind": "server"})
 
 
 class ExtractHTTPStatusCodeTag(unittest.TestCase):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds the `span.kind` tag with the value `server` for all events that represent an HTTP Request. The api security backend expects it to be present and omits endpoints that do not have this tag. (documentation for this attribute can be found [here](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/2357395856/Span+attributes#span.kind))


Additionally API Security should be enabled by default, there is no need to intentionally disable it for Appsec in lambda.

### Motivation

The goal of this PR is to make Lambda services with Appsec API Security enabled show up on the API Security Catalog.

### Testing Guidelines

Updated existing tests

### Additional Notes

- This issue also impacts API Security when it is enabled through the extension.

- As of today, the API Security Endpoint Catalog uses the `resource_name` to display the endpoint and expects it to be in the format `GET /path/to/resource` but lambda sets it to the function name instead. This should maybe be solved in the backend and will be done at a later time.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
