### PR TITLE
fix: support ddtrace 3.x.x, including >=3.15

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -65,7 +65,11 @@ if config.llmobs_enabled:
 
 if config.exception_replay_enabled:
     from ddtrace.debugging._exception.replay import SpanExceptionHandler
-    from ddtrace.debugging._uploader import LogsIntakeUploaderV1
+
+    try:
+        from ddtrace.debugging._uploader import SignalUploader
+    except ImportError:
+        from ddtrace.debugging._uploader import LogsIntakeUploaderV1 as SignalUploader
 
 logger = logging.getLogger(__name__)
 
@@ -370,7 +374,7 @@ class _LambdaDecorator(object):
 
             # Flush exception replay
             if config.exception_replay_enabled:
-                LogsIntakeUploaderV1._instance.periodic()
+                SignalUploader._instance.periodic()
 
             if config.encode_authorizer_context and is_authorizer_response(
                 self.response


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
ddtrace-py 3.15 replaced `ddtrace.debugging._uploader.LogsIntakeUploaderV1` with `ddtrace.debugging._uploader.SignalsUploader` so this project needs a little logic to import the right class.

### Motivation

<!--- What inspired you to submit this pull request? --->
After dependabot having updated ddtrace, datadog_lambda failed in our application.

### Testing Guidelines

<!--- How did you test this pull request? --->
Would love to have your help on testing this tbh.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
