### PR TITLE
Improve testing for ddtrace imports.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "main"
   pull_request:
+  schedule:
+    - cron: '0 0,12 * * *' # Runs every day at midnight and noon utc
 
 jobs:
   lint:

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -46,6 +46,10 @@ from datadog_lambda.trigger import (
     extract_http_status_code_tag,
 )
 
+# ddtrace imports are also tested in
+# dd-trace-py/tests/internal/test_serverless.py please update those tests when
+# making changes to any ddtrace import.
+
 if config.appsec_enabled:
     from datadog_lambda.asm import (
         asm_set_context,

--- a/scripts/check_layer_size.sh
+++ b/scripts/check_layer_size.sh
@@ -8,7 +8,7 @@
 # Compares layer size to threshold, and fails if below that threshold
 
 set -e
-MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 17 \* 1024 / 2)  # 8704 KB
+MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 9 \* 1024)      # 9216 KB
 MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 25 \* 1024)   # 25600 KB
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -844,7 +844,7 @@ def test_profiling_enabled(monkeypatch):
         Profiler_start_calls.append((args, kwargs))
         return original_Profiler_start(*args, **kwargs)
 
-    monkeypatch.setattr('datadog_lambda.wrapper.is_new_sandbox', lambda: True)
+    monkeypatch.setattr("datadog_lambda.wrapper.is_new_sandbox", lambda: True)
     monkeypatch.setattr(
         "datadog_lambda.wrapper.profiler.Profiler.start", Profiler_start
     )
@@ -882,7 +882,7 @@ def test_llmobs_enabled(monkeypatch):
         LLMObs_flush_calls.append((args, kwargs))
         return original_LLMObs_flush(*args, **kwargs)
 
-    monkeypatch.setattr('datadog_lambda.wrapper.is_new_sandbox', lambda: True)
+    monkeypatch.setattr("datadog_lambda.wrapper.is_new_sandbox", lambda: True)
     monkeypatch.setattr("datadog_lambda.wrapper.LLMObs.enable", LLMObs_enable)
     monkeypatch.setattr("datadog_lambda.wrapper.LLMObs.flush", LLMObs_flush)
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -882,7 +882,6 @@ def test_llmobs_enabled(monkeypatch):
         LLMObs_flush_calls.append((args, kwargs))
         return original_LLMObs_flush(*args, **kwargs)
 
-    monkeypatch.setattr("datadog_lambda.wrapper.is_new_sandbox", lambda: True)
     monkeypatch.setattr("datadog_lambda.wrapper.LLMObs.enable", LLMObs_enable)
     monkeypatch.setattr("datadog_lambda.wrapper.LLMObs.flush", LLMObs_flush)
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

1. Runs unit tests twice daily using the latest datadog-lambda code from main and the most recently released ddtrace.
2. Adds missing tests for specific imports within `datadog_lambda.wrapper`

### Motivation

<!--- What inspired you to submit this pull request? --->
https://github.com/DataDog/datadog-lambda-python/pull/661

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->
We should ideally also have similar tests in dd-trace-py to ensure that these methods are not renamed in the first place.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
