### PR TITLE
fix(http): http.url tag should contain the path

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -325,7 +325,8 @@ def extract_http_tags(event):
             method = apigateway_v2_http.get("method")
 
     if path:
-        http_tags["http.url_details.path"] = path
+        if http_tags.get("http.url"):
+            http_tags["http.url"] += path
     if method:
         http_tags["http.method"] = method
 

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -105,8 +105,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -772,8 +771,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -85,8 +85,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com",
-          "http.url_details.path": "/Prod/",
+          "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/Prod/",
           "http.method": "GET",
           "http.route": "/",
           "http.status_code": "200"
@@ -828,8 +827,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "function_trigger.event_source": "api-gateway",
           "function_trigger.event_source_arn": "XXXX$default",
           "span.kind": "server",
-          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com",
-          "http.url_details.path": "/httpapi/get",
+          "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.route": "/httpapi/get",
           "http.status_code": "200"

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -318,8 +318,7 @@ class GetTriggerTags(unittest.TestCase):
             {
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/1234567890/stages/prod",
-                "http.url": "https://70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
-                "http.url_details.path": "/prod/path/to/resource",
+                "http.url": "https://70ixmpl4fl.execute-api.us-east-2.amazonaws.com/prod/path/to/resource",
                 "http.method": "POST",
                 "http.route": "/{proxy+}",
                 "span.kind": "server",
@@ -338,8 +337,7 @@ class GetTriggerTags(unittest.TestCase):
             {
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/lgxbo6a518/stages/dev",
-                "http.url": "https://lgxbo6a518.execute-api.eu-west-1.amazonaws.com",
-                "http.url_details.path": "/dev/http/get",
+                "http.url": "https://lgxbo6a518.execute-api.eu-west-1.amazonaws.com/dev/http/get",
                 "http.method": "GET",
                 "http.route": "/http/get",
                 "span.kind": "server",
@@ -409,8 +407,7 @@ class GetTriggerTags(unittest.TestCase):
             {
                 "function_trigger.event_source": "api-gateway",
                 "function_trigger.event_source_arn": "arn:aws:apigateway:us-west-1::/restapis/x02yirxc7a/stages/$default",
-                "http.url": "https://x02yirxc7a.execute-api.eu-west-1.amazonaws.com",
-                "http.url_details.path": "/httpapi/get",
+                "http.url": "https://x02yirxc7a.execute-api.eu-west-1.amazonaws.com/httpapi/get",
                 "http.method": "GET",
                 "span.kind": "server",
                 "http.route": "/httpapi/get",
@@ -429,7 +426,6 @@ class GetTriggerTags(unittest.TestCase):
             {
                 "function_trigger.event_source": "application-load-balancer",
                 "function_trigger.event_source_arn": "arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-xyz/123abc",
-                "http.url_details.path": "/lambda",
                 "http.method": "GET",
                 "span.kind": "server",
             },
@@ -596,7 +592,6 @@ class GetTriggerTags(unittest.TestCase):
             http_tags,
             {
                 "span.kind": "server",
-                "http.url_details.path": "/test",
                 "http.method": "GET",
             },
         )


### PR DESCRIPTION
### What does this PR do?

The `http.url_details.path` tag is set by the backend as described in [the span attributes guide of APM](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/2357395856/Span+attributes#http.url_details.path). When set by this tracer, it is replaced by the backend by a value parsed from the `http.url` which is always `/`.

Here is an example of a trace received from an API Gateway event where the route can be correctly determined but the path is wrongly set for this reason:
<img width="749" height="220" alt="image" src="https://github.com/user-attachments/assets/f96ce4b4-c24f-44e0-a881-b0fb9837a005" />

The path should be appended to the `http.url` tag instead.

### Motivation

- In the App and API Protection security traces explorer, we show the endpoint and the path is reported incorrectly for this reason.
<img width="581" height="104" alt="image" src="https://github.com/user-attachments/assets/137f3018-41dd-46b0-8006-0cd2dae6750e" /> 

instead of the expected:
<img width="602" height="104" alt="image" src="https://github.com/user-attachments/assets/328e1243-83b0-4e6a-95e8-fe190939e7c9" />


### Testing Guidelines

- Updated snapshots
- Updated unit tests
- Tested with API Gateway events where scheme and host are extracted
- Tested with ALB events where `http.url` is only set to the path

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
