### PR TITLE
APMSVLS-212 Reducing Python Lambda Layer Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,8 @@ RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.h -delete
 RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.hpp -delete
 RUN find ./python/lib/$runtime/site-packages/ddtrace -name \*.pyx -delete
 
-# Strip debug symbols using strip -g for all .so files in ddtrace. This is to
+# Strip debug symbols and symbols that are not needed for relocation
+# processing  using strip --strip-unneeded for all .so files. This is to
 # reduce the size when ddtrace is built from sources. The release wheels are
 # already stripped of debug symbols. We should revisit this when serverless
 # benchmark uses pre-built wheels instead of building from sources.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Applies `strip --strip-unneeded` to all `.so` files included in the Python lambda layer. 

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Frequent increases in Python lambda layer size, exceeding checks. 
Stripping binaries further (originally only applied `strip --strip-debug`) can reduce the unzipped layer size by about 2.5MB. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Ran serverless e2e tests and manually inspected traces on a Python sample app. Manually checked that profiling and appsec still produced appropriate output. Used layer `arn:aws:lambda:us-west-2:425362996713:layer:Python312-strip-unneeded-rithika:1` on an ARM Python 3.12 lambda function.  
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
