### PR TITLE
feat(config): enable telemetry when SCA is on independently from appsec

### DIFF
--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,12 +1,5 @@
+import datadog_lambda.config  # noqa: F401 needs to be imported before `ddtrace`
 from datadog_lambda.cold_start import initialize_cold_start_tracing
-import os
-
-
-if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED") is None:
-    # Telemetry is required for Appsec Software Composition Analysis
-    os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = os.environ.get(
-        "DD_APPSEC_ENABLED", "false"
-    )
 
 
 initialize_cold_start_tracing()

--- a/datadog_lambda/config.py
+++ b/datadog_lambda/config.py
@@ -82,12 +82,6 @@ class Config:
     logs_injection = _get_env("DD_LOGS_INJECTION", "true", as_bool)
     merge_xray_traces = _get_env("DD_MERGE_XRAY_TRACES", "false", as_bool)
 
-    telemetry_enabled = _get_env(
-        "DD_INSTRUMENTATION_TELEMETRY_ENABLED",
-        "false",
-        as_bool,
-        depends_on_tracing=True,
-    )
     otel_enabled = _get_env("DD_TRACE_OTEL_ENABLED", "false", as_bool)
     profiling_enabled = _get_env("DD_PROFILING_ENABLED", "false", as_bool)
     llmobs_enabled = _get_env("DD_LLMOBS_ENABLED", "false", as_bool)
@@ -96,6 +90,7 @@ class Config:
         "DD_DATA_STREAMS_ENABLED", "false", as_bool, depends_on_tracing=True
     )
     appsec_enabled = _get_env("DD_APPSEC_ENABLED", "false", as_bool)
+    sca_enabled = _get_env("DD_APPSEC_SCA_ENABLED", "false", as_bool)
 
     is_gov_region = _get_env("AWS_REGION", "", lambda x: x.startswith("us-gov-"))
 
@@ -144,3 +139,11 @@ if config.is_gov_region or config.fips_mode_enabled:
         "Python Lambda Layer FIPS mode is %s.",
         "enabled" if config.fips_mode_enabled else "not enabled",
     )
+
+
+if (
+    "DD_INSTRUMENTATION_TELEMETRY_ENABLED" not in os.environ
+    and not config.sca_enabled
+    and not config.appsec_enabled
+):
+    os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -55,11 +55,6 @@ if config.otel_enabled:
 logger = logging.getLogger(__name__)
 
 dd_trace_context = None
-if config.telemetry_enabled:
-    # Enable the telemetry client if the user has opted in
-    from ddtrace.internal.telemetry import telemetry_writer
-
-    telemetry_writer.enable()
 
 propagator = HTTPPropagator()
 


### PR DESCRIPTION
### What does this PR do?

My understanding is that we want instrumentation telemetry to be off by default in python lambda. There is currently a bypass for AppSec that is a bit weird using env vars directly in `__init__.py`. I added another bypass for Runtime SCA and moved the logic to the `config` module to rely on parsed env vars instead.

### Motivation

A customer asked if he could enable Runtime SCA without enabling AAP (AppSec) in Lambda. This currently requires setting `DD_INSTRUMENTATION_TELEMETRY_ENABLED` manually, we could make it a bit more easy.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

- In `ddtrace`, the telemetry_writer is instantiated and enabled on first import if `DD_INSTRUMENTATION_TELEMETRY_ENABLED` is not explicitely set to false => The current telemetry enablement code in `datadog_lambda/tracing.py` is therefore redundant and unnecessary so I removed it.
- The `config.enable_telemetry` flag was therefore not necessary anymore and I removed it.

- This small refactor relies on the fact that the configuration is resolved before importing ddtrace which happens transitively through `cold_start.py`. Should we make this more explicit by importing it in `__init__.py` or is this already clear enough ? 

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
