### PR TITLE
Switch to Python Profiling v2 from v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN rm -rf ./python/lib/$runtime/site-packages/jsonschema/tests
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_ast/iastpatch*.so
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_taint_tracking/*.so
 RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/appsec/_iast/_stacktrace*.so
-# _stack_v2 may not exist for some versions of ddtrace (e.g. under python 3.13)
-RUN rm -f ./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so
 # remove *.dist-info directories except any entry_points.txt files and METADATA files required for Appsec Software Composition Analysis
 RUN find ./python/lib/$runtime/site-packages/*.dist-info \
         -type f \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Includes `./python/lib/$runtime/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.*.so` in Python Lambda layer to enable python profiling v2. 

<!--- A brief description of the change being made with this pull request. --->

### Motivation
The profiling team is planning on deprecating profiling v1 in the dd-trace-py 4.x release. We want to move lambdas to v2 before this happens. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Tested profiling on a API Gateway -> Lambda -> SQS -> Lambda setup using custom lambda layer `arn:aws:lambda:us-west-2:425362996713:layer:Python313-profilingv2-rithika:1.` Invoked producer lambda repeatedly in a short timespan to generate profiles. Inspected profiles in the Datadog UI and checked logs to ensure that ["failing back to v1 stack sampler"](https://github.com/DataDog/dd-trace-py/blob/11fdb8b3b1f03e1c52ad1e1923a07868ecb8682d/ddtrace/settings/profiling.py#L393) warning log no longer appears. [Profiles for producer lambda](https://ddserverless.datadoghq.com/profiling/explorer?query=service%3Arithika-producer-python&agg_m=%40prof_python_cpu_cores&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=enabled&refresh_mode=paused&top_n=100&top_o=top&viz=flame_graph&x_missing=true&from_ts=1762977796114&to_ts=1762981396114&live=false)

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [X] This PR passes the integration tests (ask a Datadog member to run the tests)
