### PR TITLE
Adds fail-fast on build job

### DIFF
--- a/.github/workflows/build_layer.yml
+++ b/.github/workflows/build_layer.yml
@@ -2,9 +2,6 @@ name: Build Layers for system-Tests
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - "**"
   push:
     branches:
       - "main"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

* Adds a workflow_dispacth event to allow to trigger the job manually
* ~Adds a PR event, to ensure no PR will break this jobs~  will do on a next PR
* Adds fail-fast, to allow other job to finish. The only point needed in system-tests is in success, but other builds fails, and prevent it to run.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

system-tests lambda test are broken for a week, because this jobs failed. 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
