### PR TITLE
ddtrace version less than 3.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 python = ">=3.8.0,<4"
 datadog = ">=0.51.0,<1.0.0"
 wrapt = "^1.11.2"
-ddtrace = ">=3.16.2,!=3.19.0,<4"
+ddtrace = ">=3.16.2,<3.19.0"
 ujson = ">=5.9.0"
 botocore = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Pins version of ddtracepy used in lambda layer to be less than 3.19.0.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Versions greater than or equal to 3.19.0 contain a breaking change to the signature of a function we use in the lambda layer. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
