### PR TITLE
ci(system-tests): avoid rebuilding ddtrace from source

### DIFF
--- a/.github/workflows/build_layer.yml
+++ b/.github/workflows/build_layer.yml
@@ -8,23 +8,74 @@ on:
       - "main"
 
 jobs:
+  get-ddtrace-run-id:
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ steps.get-ddtrace-run-id.outputs.run_id }}
+    steps:
+      - name: Resolve Run ID of latest dd-trace-py build
+        id: get-ddtrace-run-id
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_ID=$(gh run list \
+            --repo DataDog/dd-trace-py \
+            --workflow build_deploy.yml \
+            --branch main \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    needs: get-ddtrace-run-id
 
     strategy:
       fail-fast: false
       matrix:
         arch: [arm64, amd64]
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Build artifact name
+        id: build-artifact-name
+        run: |
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            ARCH="x86_64"
+          else
+            ARCH="aarch64"
+          fi
+
+          VER="${{ matrix.python_version }}"
+          PY_VERSION_NO_DOT="${VER//./}"
+
+          echo "artifact_name=wheels-cp${PY_VERSION_NO_DOT}-manylinux_${ARCH}" >> $GITHUB_OUTPUT
+
+      - name: Download ddtrace Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.build-artifact-name.outputs.artifact_name }}
+          repository: DataDog/dd-trace-py
+          run-id: ${{ needs.get-ddtrace-run-id.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./artifacts
+
+      - name: Find ddtrace Wheel
+        id: find-ddtrace-wheel
+        run: |
+          echo "wheel_path=$(find ./artifacts -name "*.whl" | head -n 1)" >> $GITHUB_OUTPUT
+
       - name: Patch pyproject.toml
         run: |
-          echo "Patching pyproject.toml to use main branch of dd-trace-py"
-          sed -i 's|^ddtrace =.*$|ddtrace = { git = "https://github.com/DataDog/dd-trace-py.git" }|' pyproject.toml
+          echo "Patching pyproject.toml to use latest build of dd-trace-py"
+          sed -i 's|^ddtrace =.*$|ddtrace = { file = "${{ steps.find-ddtrace-wheel.outputs.wheel_path }}" }|' pyproject.toml
 
       - name: Build layer for Python ${{ matrix.python_version }} on ${{ matrix.arch }}
         run: |


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR improves the github action that builds layers for the system-tests by avoiding to rebuild `ddtrace` from source and fetching wheels from the `dd-trace-py` pipeline instead.

### Motivation

- Reduce job duration from ~13-15mins to ~2mins

### Testing Guidelines

Triggered the pipeline on this branch: https://github.com/DataDog/datadog-lambda-python/actions/runs/19826626595

### Additional Notes

- dd-trace-py does not produce artifacts for python 3.8 and system-tests does not use the resulting build either, so I removed it

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
