### PR TITLE
Stop running update-snapshots nightly.

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,8 +1,7 @@
 name: update-snapshots
 
 on:
-  schedule:
-    - cron: "0 15 * * *" # every day 11am EST
+  workflow_dispatch:
 
 jobs:
   check:
@@ -47,8 +46,19 @@ jobs:
         working-directory: tests/integration
         run: yarn install
 
-      - name: Update Snapshots
+      - name: Update Snapshots (amd64)
         env:
+          ARCH: amd64
+          UPDATE_SNAPSHOTS: true
+          BUILD_LAYERS: true
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ./scripts/run_integration_tests.sh
+
+      - name: Update Snapshots (arm64)
+        env:
+          ARCH: arm64
           UPDATE_SNAPSHOTS: true
           BUILD_LAYERS: true
           DD_API_KEY: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes perma-failing update-snapshots gh action.
+ Do not run nightly and instead allow manual runs
+ Add missing `$ARCH` env var

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Since there's currently no way to trigger this action manually, we won't be able to test until this is merged. I think that's fine, cuz we never use these jobs anyway.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
