### PR TITLE
Catch errors when importing profiler.

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -68,7 +68,7 @@ if config.profiling_enabled:
     try:
         from ddtrace.profiling import profiler
     except Exception as e:
-        logger.error(f'Failed to initialize profiler: [{e.__class__.__name__})] {e}')
+        logger.error(f"Failed to initialize profiler: [{e.__class__.__name__})] {e}")
 
 if config.llmobs_enabled:
     from ddtrace.llmobs import LLMObs

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -967,6 +967,8 @@ def test_batch_item_failures_metric_no_response():
 @patch("datadog_lambda.config.Config.profiling_enabled", True)
 def test_profiling_import_errors_caught(monkeypatch):
     # when importing profiler fails, disable profiling instead of crashing app
-    monkeypatch.setitem(sys.modules, "ddtrace.profiling", None)  # force ModuleNotFoundError
+    monkeypatch.setitem(
+        sys.modules, "ddtrace.profiling", None
+    )  # force ModuleNotFoundError
     importlib.reload(wrapper)
     assert not hasattr(wrapper.datadog_lambda_wrapper, "prof")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

ddtrace v3.18.1 (the most recent version of ddtrace supported by this library at this time) does not yet support python 3.14 for profiling. When the profiler is attempted to be imported, an exception is raised and the whole lambda function will crash. This PR simply catches the error, logs a message, and proceeds without the profiler enabled.

### Motivation

<!--- What inspired you to submit this pull request? --->

We shouldn't crash apps.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
