### PR TITLE
feat(aap): update tags on inferred spans for API Gateway

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -346,8 +346,16 @@ class _LambdaDecorator(object):
                 if status_code:
                     self.inferred_span.set_tag("http.status_code", status_code)
 
-                if self.trigger_tags and (route := self.trigger_tags.get("http.route")):
-                    self.inferred_span.set_tag("http.route", route)
+                if self.trigger_tags:
+                    route = self.trigger_tags.get("http.route")
+                    if route:
+                        self.inferred_span.set_tag("http.route", route)
+
+                    event_source_arn = self.trigger_tags.get(
+                        "function_trigger.event_source_arn"
+                    )
+                    if event_source_arn:
+                        self.inferred_span.set_tag("dd_resource_key", event_source_arn)
 
                 if config.service:
                     self.inferred_span.set_tag("peer.service", config.service)

--- a/tests/integration/snapshots/logs/async-metrics_python310.log
+++ b/tests/integration/snapshots/logs/async-metrics_python310.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python311.log
+++ b/tests/integration/snapshots/logs/async-metrics_python311.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python312.log
+++ b/tests/integration/snapshots/logs/async-metrics_python312.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python313.log
+++ b/tests/integration/snapshots/logs/async-metrics_python313.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python314.log
+++ b/tests/integration/snapshots/logs/async-metrics_python314.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python38.log
+++ b/tests/integration/snapshots/logs/async-metrics_python38.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/async-metrics_python39.log
+++ b/tests/integration/snapshots/logs/async-metrics_python39.log
@@ -54,11 +54,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -68,6 +68,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -76,10 +77,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -375,6 +377,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -383,6 +386,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -574,6 +578,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -718,13 +723,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -734,6 +738,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -742,10 +747,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -904,6 +910,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -912,6 +919,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1066,6 +1074,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1074,6 +1083,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1241,6 +1251,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1249,6 +1260,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1403,6 +1415,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1411,6 +1424,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1571,6 +1585,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1579,6 +1594,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python310.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python310.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python311.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python311.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python312.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python312.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python313.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python313.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python314.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python314.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python38.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python38.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/integration/snapshots/logs/sync-metrics_python39.log
+++ b/tests/integration/snapshots/logs/sync-metrics_python39.log
@@ -34,11 +34,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.apigateway.rest",
           "http.url": "https://XXXX.execute-api.us-east-2.amazonaws.com/",
           "endpoint": "/",
           "http.method": "GET",
           "resource_names": "GET /",
+          "http.useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
           "span.kind": "server",
           "apiid": "XXXX",
           "apiname": "XXXX",
@@ -48,6 +48,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/70ixmpl4fl/stages/Prod",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -56,10 +57,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -393,6 +395,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "size_bytes": "26",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:dynamodb:us-east-1:XXXX:us-east-1/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -401,6 +404,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -611,6 +615,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -774,13 +779,12 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         "meta": {
           "runtime-id": "XXXX",
           "_dd.origin": "lambda",
-          "operation_name": "aws.httpapi",
           "endpoint": "/httpapi/get",
           "http.url": "https://XXXX.execute-api.eu-west-1.amazonaws.com/httpapi/get",
           "http.method": "GET",
           "http.protocol": "HTTP/1.1",
           "http.source_ip": "XXXX",
-          "http.user_agent": "XXXX/7.64.1",
+          "http.useragent": "curl/7.64.1",
           "resource_names": "GET /httpapi/get",
           "request_id": "XXXX",
           "apiid": "XXXX",
@@ -790,6 +794,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
           "http.route": "/httpapi/get",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/x02yirxc7a/stages/$default",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -798,10 +803,11 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
-        "type": "http"
+        "type": "web"
       },
       {
         "trace_id": "XXXX",
@@ -979,6 +985,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "partition_key": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:kinesis:EXAMPLE",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -987,6 +994,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1160,6 +1168,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "object_etag": "XXXX",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:s3:::example-bucket",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1168,6 +1177,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1354,6 +1364,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "subject": "TestInvoke",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sns:us-east-2:XXXX:us-east-2-lambda",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1362,6 +1373,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1535,6 +1547,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "sender_id": "AIDAIENQZJOLO23YVJ4VO",
           "_inferred_span.synchronicity": "async",
           "_inferred_span.tag_source": "self",
+          "dd_resource_key": "arn:aws:sqs:us-east-2:XXXX:us-east-2-queue",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1543,6 +1556,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },
@@ -1722,6 +1736,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
           "_inferred_span.synchronicity": "sync",
           "_inferred_span.tag_source": "self",
           "http.status_code": "200",
+          "dd_resource_key": "arn:aws:apigateway:eu-west-1:XXXX:eu-west-1/restapis/p62c47itsb/stages/dev",
           "peer.service": "integration-tests-python",
           "_dd.peer.service.source": "peer.service",
           "_dd.p.dm": "-0",
@@ -1730,6 +1745,7 @@ HTTP GET https://www.datadoghq.com/ Headers: ["Accept-Encoding:gzip, deflate","A
         },
         "metrics": {
           "process_id": XXXX,
+          "_dd._inferred_span": 1,
           "_dd.top_level": 1,
           "_sampling_priority_v1": 1
         },

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1380,7 +1380,6 @@ class TestServiceMapping(unittest.TestCase):
         ctx.aws_request_id = "123"
 
         span1 = create_inferred_span(original_event, ctx)
-        self.assertEqual(span1.get_tag("operation_name"), "aws.apigateway.rest")
         self.assertEqual(span1.service, "new-name")
 
         # Testing the second event
@@ -1389,7 +1388,6 @@ class TestServiceMapping(unittest.TestCase):
             "domainName"
         ] = "different.execute-api.us-east-2.amazonaws.com"
         span2 = create_inferred_span(event2, ctx)
-        self.assertEqual(span2.get_tag("operation_name"), "aws.apigateway.rest")
         self.assertEqual(span2.service, "new-name")
 
     def test_remaps_specific_inferred_span_service_names_from_api_gateway_event(
@@ -1406,14 +1404,12 @@ class TestServiceMapping(unittest.TestCase):
         ctx.aws_request_id = "123"
 
         span1 = create_inferred_span(original_event, ctx)
-        self.assertEqual(span1.get_tag("operation_name"), "aws.apigateway.rest")
         self.assertEqual(span1.service, "new-name")
 
         # Testing the second event
         event2 = copy.deepcopy(original_event)
         event2["requestContext"]["apiId"] = "different"
         span2 = create_inferred_span(event2, ctx)
-        self.assertEqual(span2.get_tag("operation_name"), "aws.apigateway.rest")
         self.assertEqual(
             span2.service, "70ixmpl4fl.execute-api.us-east-2.amazonaws.com"
         )
@@ -1456,14 +1452,12 @@ class TestServiceMapping(unittest.TestCase):
         ctx.aws_request_id = "123"
 
         span1 = create_inferred_span(original_event, ctx)
-        self.assertEqual(span1.get_tag("operation_name"), "aws.httpapi")
         self.assertEqual(span1.service, "new-name")
 
         # Testing the second event
         event2 = copy.deepcopy(original_event)
         event2["requestContext"]["apiId"] = "different"
         span2 = create_inferred_span(event2, ctx)
-        self.assertEqual(span2.get_tag("operation_name"), "aws.httpapi")
         self.assertEqual(
             span2.service, "x02yirxc7a.execute-api.eu-west-1.amazonaws.com"
         )
@@ -1804,7 +1798,7 @@ _test_create_inferred_span = (
         _Span(
             service="70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
             start=1428582896.0,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -1814,7 +1808,7 @@ _test_create_inferred_span = (
                 "endpoint": "/path/to/resource",
                 "http.method": "POST",
                 "http.url": "https://70ixmpl4fl.execute-api.us-east-2.amazonaws.com/path/to/resource",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "Custom User Agent String",
                 "request_id": "123",
                 "resource_names": "POST /{proxy+}",
                 "stage": "prod",
@@ -1826,7 +1820,7 @@ _test_create_inferred_span = (
         _Span(
             service="lgxbo6a518.execute-api.eu-west-1.amazonaws.com",
             start=1631210915.2510002,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "async",
@@ -1836,7 +1830,7 @@ _test_create_inferred_span = (
                 "endpoint": "/http/get",
                 "http.method": "GET",
                 "http.url": "https://lgxbo6a518.execute-api.eu-west-1.amazonaws.com/http/get",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "curl/7.64.1",
                 "request_id": "123",
                 "resource_names": "GET /http/get",
                 "stage": "dev",
@@ -1848,7 +1842,7 @@ _test_create_inferred_span = (
         _Span(
             service="lgxbo6a518.execute-api.eu-west-1.amazonaws.com",
             start=1631210915.2510002,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -1858,7 +1852,7 @@ _test_create_inferred_span = (
                 "endpoint": "/http/get",
                 "http.method": "GET",
                 "http.url": "https://lgxbo6a518.execute-api.eu-west-1.amazonaws.com/http/get",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "curl/7.64.1",
                 "request_id": "123",
                 "resource_names": "GET /http/get",
                 "stage": "dev",
@@ -1870,7 +1864,7 @@ _test_create_inferred_span = (
         _Span(
             service="x02yirxc7a.execute-api.eu-west-1.amazonaws.com",
             start=1631212283.738,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -1882,8 +1876,7 @@ _test_create_inferred_span = (
                 "http.protocol": "HTTP/1.1",
                 "http.source_ip": "38.122.226.210",
                 "http.url": "https://x02yirxc7a.execute-api.eu-west-1.amazonaws.com/httpapi/get",
-                "http.user_agent": "curl/7.64.1",
-                "operation_name": "aws.httpapi",
+                "http.useragent": "curl/7.64.1",
                 "request_id": "123",
                 "resource_names": "GET /httpapi/get",
                 "stage": "$default",
@@ -1895,7 +1888,7 @@ _test_create_inferred_span = (
         _Span(
             service="mcwkra0ya4.execute-api.sa-east-1.amazonaws.com",
             start=1710529824.52,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -1905,7 +1898,7 @@ _test_create_inferred_span = (
                 "endpoint": "/user/42",
                 "http.method": "GET",
                 "http.url": "https://mcwkra0ya4.execute-api.sa-east-1.amazonaws.com/user/42",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "curl/8.1.2",
                 "request_id": "123",
                 "resource_names": "GET /user/{id}",
                 "stage": "dev",
@@ -1917,7 +1910,7 @@ _test_create_inferred_span = (
         _Span(
             service="9vj54we5ih.execute-api.sa-east-1.amazonaws.com",
             start=1710529905.066,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -1927,7 +1920,7 @@ _test_create_inferred_span = (
                 "endpoint": "/user/42",
                 "http.method": "GET",
                 "http.url": "https://9vj54we5ih.execute-api.sa-east-1.amazonaws.com/user/42",
-                "operation_name": "aws.httpapi",
+                "http.useragent": "curl/8.1.2",
                 "request_id": "123",
                 "resource_names": "GET /user/{id}",
                 "stage": "$default",
@@ -2186,7 +2179,7 @@ _test_create_inferred_span = (
         _Span(
             service="70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
             start=1428582896.0,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -2196,7 +2189,7 @@ _test_create_inferred_span = (
                 "endpoint": "/path/to/resource",
                 "http.method": "POST",
                 "http.url": "https://70ixmpl4fl.execute-api.us-east-2.amazonaws.com/path/to/resource",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "Custom User Agent String",
                 "request_id": "123",
                 "resource_names": "POST /{proxy+}",
                 "stage": "prod",
@@ -2208,7 +2201,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1663295021.832,
-            span_type="http",
+            span_type="web",
             parent_name="aws.apigateway.authorizer",
             tags={
                 "_dd.origin": "lambda",
@@ -2219,7 +2212,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "PostmanRuntime/7.29.2",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",
@@ -2231,7 +2224,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1666714653.636,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -2241,7 +2234,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "PostmanRuntime/7.29.2",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",
@@ -2253,7 +2246,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1663295021.832,
-            span_type="http",
+            span_type="web",
             parent_name="aws.apigateway.authorizer",
             tags={
                 "_dd.origin": "lambda",
@@ -2264,7 +2257,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "PostmanRuntime/7.29.2",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",
@@ -2276,7 +2269,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1666803622.99,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -2286,7 +2279,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.apigateway.rest",
+                "http.useragent": "PostmanRuntime/7.29.2",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",
@@ -2298,7 +2291,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1664228639.5337753,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -2308,7 +2301,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.httpapi",
+                "http.useragent": "curl/7.64.1",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",
@@ -2320,7 +2313,7 @@ _test_create_inferred_span = (
         _Span(
             service="amddr1rix9.execute-api.eu-west-1.amazonaws.com",
             start=1666715429.349,
-            span_type="http",
+            span_type="web",
             tags={
                 "_dd.origin": "lambda",
                 "_inferred_span.synchronicity": "sync",
@@ -2330,7 +2323,7 @@ _test_create_inferred_span = (
                 "endpoint": "/hello",
                 "http.method": "GET",
                 "http.url": "https://amddr1rix9.execute-api.eu-west-1.amazonaws.com/hello",
-                "operation_name": "aws.httpapi",
+                "http.useragent": "PostmanRuntime/7.29.2",
                 "request_id": "123",
                 "resource_names": "GET /hello",
                 "stage": "dev",


### PR DESCRIPTION
### What does this PR do?

It updates tags for API Gateway Rest Proxy and HTTP API inferred spans, to enable discovery by both the APM Endpoint Catalog and the API Gateway Catalog: 

From the RFC:
<img width="1023" height="294" alt="image" src="https://github.com/user-attachments/assets/19282926-4eca-45fe-9b28-0987861123ff" />


- For API Gateway v1 and v2:
  - remove operation_name
  - switch span_type to "web"
  - [NOT Specified by the RFC] set "http.useragent" (instead of `http.user_agent` or when missing); this is the tag specified in the "Span attributes" page of APM ( and the tag that is used by the system-tests to correlate spans with requests, this helps testing this feature there and is more "conformant")
 
 - For all inferred spans (necessary only for API Gateway, but works the same everywhere so might as well do it):
   -   add `dd_resource_key` tag to inferred spans with the `event_source_arn`
   - [NOT Specified by the RFC]  set the `_dd.inferred_span` metric, the backend filters inferred spans for the APM Catalog (and the AAP Catalog) based on this metric. It is already set by tracers for the API Gateway proxy inferred spans.
  
### Motivation

This PR implements tags updates for RFC-1081.

The goal is be able to use API Gateway lambda inferred spans for endpoint discovery and correlation in the AppSec API Catalog. 

### Testing Guidelines

- unit tests: updated
- snapshot tests: updated
- system-tests done but not merged yet: http://github.com/DataDog/system-tests/pull/5830

### Additional Notes

- I haven't removed `apiname` yet as it is not required and might break something somewhere. If a serverless reviewer can confirm that we don't need it anymore, let's remove it now. 

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (removal of `operation_name` and changing type of inferred spans from `http` to `web`)
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
