### PR TITLE
Running Gitlab jobs based on upstream pipeline existence

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  SKIP_E2E_TESTS: false
+  SKIP_E2E_TESTS: "false"
 
 stages:
   - pre 

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -142,7 +142,7 @@ publish-layer-{{ $environment_name }} ({{ $runtime.name }}-{{ $runtime.arch }}):
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/docker:20.10-py3
   rules:
-    - if: '$SKIP_E2E_TESTS == true'
+    - if: '$SKIP_E2E_TESTS == "true"'
       when: never
     - if: '"{{ $environment_name }}" == "sandbox" && $REGION == "{{ $e2e_region }}" && "{{ $runtime.arch }}" == "amd64"'
       when: on_success
@@ -250,7 +250,7 @@ e2e-test:
     project: DataDog/serverless-e2e-tests
     strategy: depend
   rules:
-    - if: '$SKIP_E2E_TESTS == true'
+    - if: '$SKIP_E2E_TESTS == "true"'
       when: never
     - when: on_success
   variables:
@@ -274,7 +274,7 @@ e2e-test-status:
   tags: ["arch:amd64"]
   timeout: 3h
   rules:
-    - if: '$SKIP_E2E_TESTS == true'
+    - if: '$SKIP_E2E_TESTS == "true"'
       when: never
     - when: on_success
   script: |


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Triggers certain Gitlab jobs (e2e tests and jobs relating to publishing the layer) to run only when the `SKIP_E2E_TESTS == false`. Allows this repo's Gitlab pipelines to be used in dd-trace-py without adding too much time or resources to their CI.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
We are adding the unit and integration tests from datadog-lambda-python to dd-trace-py CI to avoid merging changes in the tracer that break the serverless implementation.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Using CI/Gitlab. Tested that when the Gitlab pipeline was triggered from this repo, all expected jobs showed up (such as e2e tests). Tested that when the pipeline was trigger from [dd-trace-py,](https://github.com/DataDog/dd-trace-py/pull/15475) the e2e tests were not triggered, but the unit and integration tests were.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
