### PR TITLE
Address flakiness of Gitlab jobs

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -54,6 +54,7 @@ build-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
     CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
   script:
     - PYTHON_VERSION={{ $runtime.python_version }} ARCH={{ $runtime.arch }} ./scripts/build_layers.sh
+  timeout: 15m
   retry: 2
 
 check-layer-size ({{ $runtime.name }}-{{ $runtime.arch }}):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Configures automatic retires for build layer, unit test, and integration test Gitlab jobs. Skips integration tests when triggered by dd-trace-py CI. Decreases timeout on build-layer jobs to address worker OOM killing the job.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Flaky jobs.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
