### PR TITLE
Trigger layer version update in documentation

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -114,19 +114,6 @@ integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
     - RUNTIME_PARAM={{ $runtime.python_version }} ARCH={{ $runtime.arch }} ./scripts/run_integration_tests.sh
   retry: 2
 
-test-update-layer-versions-docs:
-  stage: publish
-  trigger:
-    project: DataDog/serverless-ci
-  needs: {{ range $runtime := (ds "runtimes").runtimes }}
-    - integration-test ({{ $runtime.name }}-{{ $runtime.arch}})
-  {{- end }}
-  variables:
-    RUN_LAMBDA_LAYER_DOCUMENTATION: "true"
-    RUN_LAMBDA_DATADOG_CI: "true"
-    RUN_LAMBDA_UI_LAYER_VERSIONS: "true"
-    RUN_LAMBDA_RUNTIMES: "true"
-
 sign-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: sign
   tags: ["arch:amd64"]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds Gitlab job to release pipelines to trigger DataDog/serverless-ci pipeline which will generate a PR for updating the layer version in public documentation. Then, serverless ONE will review and merge this PR. 
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Keeps public facing documentation up-to-date. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
