### PR TITLE
ci: fix broken dd-trace-py wheel downloading

### DIFF
--- a/.github/workflows/build_layer.yml
+++ b/.github/workflows/build_layer.yml
@@ -31,7 +31,7 @@ jobs:
             PLATFORM_TAG="manylinux_2_17_aarch64"
           fi
 
-          pip download --no-deps --find-links https://dd-trace-py-builds.s3.amazonaws.com/main/index.html --pre --python-version "${{ matrix.python_version}}"  --platform "${PLATFORM_TAG}" ddtrace
+          pip download --no-index --no-deps --find-links https://dd-trace-py-builds.s3.amazonaws.com/main/index.html --pre --python-version "${{ matrix.python_version}}"  --platform "${PLATFORM_TAG}" ddtrace
           echo "wheel_path=$(find . -name "*.whl" | head -n 1)" >> $GITHUB_OUTPUT
 
       - name: Patch pyproject.toml


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Update the build layer workflow to download ddtrace wheels from the publish S3 bucket: https://dd-trace-py-builds.s3.amazonaws.com/main/index.html instead of from GHA since we have moved wheel building from GHA to GitLab.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
