### PR TITLE
fix: Bump ujson minimum version to 5.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ ddtrace = [
     {version = ">=3.19.1,<4", python = ">=3.8,<3.10"},
     {version = ">=4.1.1,<5,!=4.6.*", python = ">=3.10"}
 ]
-ujson = ">=5.10.0"
+ujson = [
+    {version = ">=5.10.0,<5.12.0", python = ">=3.8,<3.10"},
+    {version = ">=5.12.0", python = ">=3.10"}
+]
 botocore = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }
 pytest = { version= "^8.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ ddtrace = [
     {version = ">=3.19.1,<4", python = ">=3.8,<3.10"},
     {version = ">=4.1.1,<5,!=4.6.*", python = ">=3.10"}
 ]
-ujson = ">=5.9.0"
+ujson = ">=5.10.0"
 botocore = { version = "^1.34.0", optional = true }
 requests = { version ="^2.22.0", optional = true }
 pytest = { version= "^8.0.0", optional = true }


### PR DESCRIPTION
Fixes #786

## Changes 

pyproject.toml — Split the ujson constraint by Python version:                                          
  - Python 3.8-3.9: >=5.10.0,<5.12.0 (best available; ujson 5.12.0 dropped Python <3.10 support)          
  - Python >=3.10: >=5.12.0 (the version that fixes both CVEs)                                            
                                                            
  poetry.lock — Updated the ujson entry to include:                                                       
  - ujson 5.12.0 with markers = "python_version >= \"3.10\""
  - ujson 5.10.0 with markers = "python_version < \"3.10\"" (only cp38/cp39 wheels)                       
                                                                                   
  This fixes CVE-2026-32874 (memory leak parsing large integers, CVSS 7.5) and CVE-2026-32875 (integer    
  overflow in indent handling, CVSS 7.5). 