### PR TITLE
chore(ci): use dd-sts for system-tests test optimization

### DIFF
--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -34,6 +34,7 @@ jobs:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
     permissions:
       contents: read
+      id-token: write
       packages: write
     with:
       library: python_lambda
@@ -41,3 +42,4 @@ jobs:
       scenarios_groups: tracer_release
       skip_empty_scenarios: true
       push_to_test_optimization: true
+      dd_sts_policy: datadog-lambda-python

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -42,4 +42,3 @@ jobs:
       scenarios_groups: tracer_release
       skip_empty_scenarios: true
       push_to_test_optimization: true
-      dd_sts_policy: datadog-lambda-python

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -34,6 +34,7 @@ jobs:
       id-token: write
     with:
       library: python_lambda
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: binaries
       scenarios_groups: tracer_release
       skip_empty_scenarios: true

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -29,9 +29,6 @@ jobs:
     needs:
       - build
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      TEST_OPTIMIZATION_API_KEY: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
     permissions:
       id-token: write
     with:

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -28,7 +28,7 @@ jobs:
   system-tests:
     needs:
       - build
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -33,9 +33,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.TEST_OPTIMIZATION_API_KEY }}
     permissions:
-      contents: read
       id-token: write
-      packages: write
     with:
       library: python_lambda
       binaries_artifact: binaries

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -30,6 +30,7 @@ jobs:
       - build
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     permissions:
+      contents: read
       id-token: write
     with:
       library: python_lambda


### PR DESCRIPTION
## Summary

Migrates system-tests CI to use [dd-sts](https://github.com/DataDog/dd-sts-action) for Datadog Test Optimization instead of long-lived API keys.

All repositories now share a single `system-tests` policy (see [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)) — no per-repo policy is needed.

Depends on [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

### Changes
- Add `id-token: write` permission to the system-tests reusable workflow call so it can obtain short-lived credentials via OIDC
- Pin system-tests to `1e5d6b709` (current `main`, pre-migration) to allow a controlled rollout: repos stay on the pre-migration workflow until their pin is explicitly updated to the post-merge SHA

## How to review

The only functional change is adding `id-token: write`. It has no effect at the pinned SHA (dd-sts is not yet used there) but will be required once each repo's pin is updated after [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726) merges.