### PR TITLE
[SVLS-8580] fix: correct durable execution statuses to match Python SDK InvocationStatus enum

### DIFF
--- a/datadog_lambda/durable.py
+++ b/datadog_lambda/durable.py
@@ -55,7 +55,7 @@ def extract_durable_function_tags(event):
     }
 
 
-VALID_DURABLE_STATUSES = {"SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"}
+VALID_DURABLE_STATUSES = {"SUCCEEDED", "FAILED", "PENDING"}
 
 
 def extract_durable_execution_status(response, event):

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -131,19 +131,12 @@ class TestExtractDurableExecutionStatus(unittest.TestCase):
         response = {"Status": "FAILED", "Error": "some-error"}
         self.assertEqual(extract_durable_execution_status(response, event), "FAILED")
 
-    def test_returns_stopped(self):
+    def test_returns_pending(self):
         event = {
             "DurableExecutionArn": "arn:aws:lambda:us-east-1:123:function:f:1/durable-execution/n/id"
         }
-        response = {"Status": "STOPPED"}
-        self.assertEqual(extract_durable_execution_status(response, event), "STOPPED")
-
-    def test_returns_timed_out(self):
-        event = {
-            "DurableExecutionArn": "arn:aws:lambda:us-east-1:123:function:f:1/durable-execution/n/id"
-        }
-        response = {"Status": "TIMED_OUT"}
-        self.assertEqual(extract_durable_execution_status(response, event), "TIMED_OUT")
+        response = {"Status": "PENDING"}
+        self.assertEqual(extract_durable_execution_status(response, event), "PENDING")
 
     def test_returns_none_for_non_durable_event(self):
         event = {"key": "value"}


### PR DESCRIPTION
## Summary

Fixes wrong statuses introduced in #751. The `VALID_DURABLE_STATUSES` set was using `STOPPED` and `TIMED_OUT`, which belong to `OperationStatus` (individual operation level). The invocation-level `InvocationStatus` enum in the Python durable execution SDK only defines:

- **SUCCEEDED**
- **FAILED**
- **PENDING**

## Changes

- `datadog_lambda/durable.py`: Replace `{"SUCCEEDED", "FAILED", "STOPPED", "TIMED_OUT"}` with `{"SUCCEEDED", "FAILED", "PENDING"}`
- `tests/test_durable.py`: Replace `test_returns_stopped` + `test_returns_timed_out` with `test_returns_pending`

## Testing
Tested with a durable function that has two invocations per execution.

The aws.lambda span for the 1st invocation has tag `execution_status:PENDING` ([link](https://ddserverless.datadoghq.com/apm/trace/14605582093092649751?graphType=flamegraph&shouldShowLegend=true&spanID=7857013803520147191&timeHint=1776225191214&traceQuery=))
<img width="526" height="361" alt="image" src="https://github.com/user-attachments/assets/8988bab6-2b0d-450a-aadb-261135609805" />

For the 2nd invocation, the tag is `execution_status:FAILED` ([link](https://ddserverless.datadoghq.com/apm/traces?query=resource_name%3Ayiming-durable&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=4903891131858536684&spanType=all&storage=hot&timeHint=1776225674974&trace=180217822722247928064903891131858536684&traceID=18021782272224792806&traceQuery=&view=spans&start=1776224823943&end=1776225723943&paused=false)) or `execution_status:SUCCEEDED` ([link](https://ddserverless.datadoghq.com/apm/traces?query=resource_name%3Ayiming-durable&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=3723840081886982825&spanType=all&storage=hot&timeHint=1776225202793&trace=51779662194240306623723840081886982825&traceID=5177966219424030662&traceQuery=&view=spans&start=1776224683078&end=1776225583078&paused=false))
<img width="524" height="340" alt="image" src="https://github.com/user-attachments/assets/aabd4037-254b-4b6f-b60e-ff50b6072f80" />

<img width="525" height="348" alt="image" src="https://github.com/user-attachments/assets/7bd50678-9308-43fd-b3cb-4b48a5b6ba48" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)