### PR TITLE
fix: disable remote configuration by default in Lambda

### DIFF
--- a/datadog_lambda/config.py
+++ b/datadog_lambda/config.py
@@ -141,11 +141,6 @@ if config.is_gov_region or config.fips_mode_enabled:
         "enabled" if config.fips_mode_enabled else "not enabled",
     )
 
-# Remote configuration relies on /dev/shm which is unavailable in Lambda.
-# Disable it before ddtrace loads to avoid the shared-memory warning.
-if "DD_REMOTE_CONFIGURATION_ENABLED" not in os.environ:
-    os.environ["DD_REMOTE_CONFIGURATION_ENABLED"] = "false"
-
 # disable css to prevent double counting in lambda
 os.environ["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "false"
 

--- a/datadog_lambda/config.py
+++ b/datadog_lambda/config.py
@@ -141,6 +141,11 @@ if config.is_gov_region or config.fips_mode_enabled:
         "enabled" if config.fips_mode_enabled else "not enabled",
     )
 
+# Remote configuration relies on /dev/shm which is unavailable in Lambda.
+# Disable it before ddtrace loads to avoid the shared-memory warning.
+if "DD_REMOTE_CONFIGURATION_ENABLED" not in os.environ:
+    os.environ["DD_REMOTE_CONFIGURATION_ENABLED"] = "false"
+
 # disable css to prevent double counting in lambda
 os.environ["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "false"
 


### PR DESCRIPTION
## Summary

Disables remote configuration by default before ddtrace loads, preventing the `Unable to create shared memory` warning on Lambda cold starts.

Resolves #785

## Context

Remote configuration in ddtrace relies on `/dev/shm` for shared memory via `multiprocessing.Array`. AWS Lambda does not provide `/dev/shm`, so the allocation fails with `FileNotFoundError` and logs a warning on every cold start — even when `DD_REMOTE_CONFIGURATION_ENABLED=false` is explicitly set — because the shared memory allocation happens at import time before the config flag is checked.

This started occurring with ddtrace v4.5.0 due to the [single RC subscriber refactor](https://github.com/DataDog/dd-trace-py/commit/74c3ab43b0) which changed `PublisherSubscriberConnector` creation from lazy (per-product registration) to eager (at module import time).

## Changes

- **`datadog_lambda/config.py`**: Set `DD_REMOTE_CONFIGURATION_ENABLED=false` in the environment before ddtrace is imported, following the same pattern already used for `DD_TRACE_STATS_COMPUTATION_ENABLED` and `DD_INSTRUMENTATION_TELEMETRY_ENABLED`. Respects explicit user overrides — only sets the default if the env var is not already present.

## Primary Fix

The primary fix is in dd-trace-py: [DataDog/dd-trace-py#17550](https://github.com/DataDog/dd-trace-py/pull/17550) — adds an `in_aws_lambda()` check in `PublisherSubscriberConnector.__init__` to skip the shared memory allocation entirely when running in Lambda.

This PR is a **defense-in-depth companion** that:
1. Ensures `ddconfig._remote_config_enabled` is `False` from the start (preventing features like Dynamic Instrumentation from force-enabling RC in Lambda)
2. Prevents the RC poller from ever being `enable()`d, even if the dd-trace-py fix is not yet deployed
3. Follows established conventions in this module for disabling features incompatible with Lambda

## Test Plan

- [ ] Existing unit tests pass
- [ ] Verify `DD_REMOTE_CONFIGURATION_ENABLED` defaults to `"false"` when not explicitly set
- [ ] Verify explicit `DD_REMOTE_CONFIGURATION_ENABLED=true` overrides the default
- [ ] No `Unable to create shared memory` warning in Lambda cold start logs