### PR TITLE
enable instrumentation telemetry

### DIFF
--- a/datadog_lambda/config.py
+++ b/datadog_lambda/config.py
@@ -152,10 +152,3 @@ os.environ["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "false"
 # unset css aliases to ensure it is disabled
 if "DD_TRACE_COMPUTE_STATS" in os.environ:
     del os.environ["DD_TRACE_COMPUTE_STATS"]
-
-if (
-    "DD_INSTRUMENTATION_TELEMETRY_ENABLED" not in os.environ
-    and not config.sca_enabled
-    and not config.appsec_enabled
-):
-    os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -31,6 +31,7 @@ from datadog_lambda.xray import (
 
 from ddtrace import patch
 from ddtrace import __version__ as ddtrace_version
+from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.trace import Context, Span, tracer
 
@@ -1509,6 +1510,10 @@ def create_function_execution_span(
                 pointer_hash=span_pointer_description.pointer_hash,
                 extra_attributes=span_pointer_description.extra_attributes,
             )
+
+    if is_cold_start():
+        telemetry_writer.periodic(force_flush=True)
+
     return span
 
 

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -1511,7 +1511,7 @@ def create_function_execution_span(
                 extra_attributes=span_pointer_description.extra_attributes,
             )
 
-    if is_cold_start():
+    if is_cold_start:
         telemetry_writer.periodic(force_flush=True)
 
     return span


### PR DESCRIPTION
This change removes the configuration that disables instrumentation telemetry and replaces it with a single telemetry upload during cold start, per the Instrumentation Telemetry For Serverless RFC.

https://github.com/DataDog/dd-trace-py/pull/17661 makes this change work as described in the Instrumentation Telemetry For Serverless RFC.