### PR TITLE
ci: update CI containers to Ubuntu 24.04

### DIFF
--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -38,7 +38,7 @@ default:
 build-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10
+  image: registry.ddbuild.io/images/ubuntu:24.04
   artifacts:
     expire_in: 1 hr # Unsigned zips expire in 1 hour
     paths:
@@ -53,7 +53,7 @@ build-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
 check-layer-size ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10
+  image: registry.ddbuild.io/images/ubuntu:24.04
   needs:
     - build-layer ({{ $runtime.name }}-{{ $runtime.arch }})
   dependencies:
@@ -92,7 +92,7 @@ unit-test ({{ $runtime.name }}-{{ $runtime.arch }}):
 integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   rules:
     - if: '$SKIP_E2E_TESTS == "true"'
       when: never
@@ -117,7 +117,7 @@ integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
 sign-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: sign
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: manual
@@ -148,7 +148,7 @@ sign-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
 publish-layer-{{ $environment_name }} ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   rules:
     - if: '$SKIP_E2E_TESTS == "true"'
       when: never
@@ -194,7 +194,7 @@ publish-layer-{{ $environment_name }} ({{ $runtime.name }}-{{ $runtime.arch }}):
 publish-pypi-package:
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   before_script:
     - ./scripts/setup_python_env.sh
   cache: []
@@ -210,7 +210,7 @@ publish-pypi-package:
 layer bundle:
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/docker:20.10
+  image: registry.ddbuild.io/images/ubuntu:24.04
   needs:
     {{ range (ds "runtimes").runtimes }}
     - build-layer ({{ .name }}-{{ .arch }})
@@ -231,7 +231,7 @@ layer bundle:
 
 signed layer bundle:
   stage: sign
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   tags: ["arch:amd64"]
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
@@ -279,7 +279,7 @@ e2e-test:
 
 e2e-test-status:
   stage: e2e
-  image: registry.ddbuild.io/images/docker:20.10-py3
+  image: registry.ddbuild.io/images/ubuntu:24.04-py3
   tags: ["arch:amd64"]
   timeout: 3h
   rules:

--- a/ci/input_files/build.yaml.tpl
+++ b/ci/input_files/build.yaml.tpl
@@ -38,7 +38,7 @@ default:
 build-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04
+  image: registry.ddbuild.io/images/docker:29.4.0-noble
   artifacts:
     expire_in: 1 hr # Unsigned zips expire in 1 hour
     paths:
@@ -53,7 +53,7 @@ build-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
 check-layer-size ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04
+  image: registry.ddbuild.io/images/docker:29.4.0-noble
   needs:
     - build-layer ({{ $runtime.name }}-{{ $runtime.arch }})
   dependencies:
@@ -92,7 +92,7 @@ unit-test ({{ $runtime.name }}-{{ $runtime.arch }}):
 integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: test
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   rules:
     - if: '$SKIP_E2E_TESTS == "true"'
       when: never
@@ -117,7 +117,7 @@ integration-test ({{ $runtime.name }}-{{ $runtime.arch }}):
 sign-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: sign
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: manual
@@ -148,7 +148,7 @@ sign-layer ({{ $runtime.name }}-{{ $runtime.arch }}):
 publish-layer-{{ $environment_name }} ({{ $runtime.name }}-{{ $runtime.arch }}):
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   rules:
     - if: '$SKIP_E2E_TESTS == "true"'
       when: never
@@ -194,7 +194,7 @@ publish-layer-{{ $environment_name }} ({{ $runtime.name }}-{{ $runtime.arch }}):
 publish-pypi-package:
   stage: publish
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   before_script:
     - ./scripts/setup_python_env.sh
   cache: []
@@ -210,7 +210,7 @@ publish-pypi-package:
 layer bundle:
   stage: build
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/ubuntu:24.04
+  image: registry.ddbuild.io/images/docker:29.4.0-noble
   needs:
     {{ range (ds "runtimes").runtimes }}
     - build-layer ({{ .name }}-{{ .arch }})
@@ -231,7 +231,7 @@ layer bundle:
 
 signed layer bundle:
   stage: sign
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   tags: ["arch:amd64"]
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
@@ -279,7 +279,7 @@ e2e-test:
 
 e2e-test-status:
   stage: e2e
-  image: registry.ddbuild.io/images/ubuntu:24.04-py3
+  image: registry.ddbuild.io/images/docker:29.4.0-noble-py3
   tags: ["arch:amd64"]
   timeout: 3h
   rules:


### PR DESCRIPTION
## Summary
- Replace all `docker:20.10` images with `ubuntu:24.04` in `ci/input_files/build.yaml.tpl`
- Replace all `docker:20.10-py3` images with `ubuntu:24.04-py3`
- Affects all CI jobs: build-layer, check-layer-size, integration-test, sign-layer, publish-layer, publish-pypi-package, layer bundle, signed layer bundle, e2e-test-status

## Test plan
- [ ] Verify CI jobs start successfully with the new Ubuntu 24.04 images
- [ ] Confirm `apt-get` based install steps continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)