### PR TITLE
[SVLS-8493] feat: Rename durable span tags from aws_lambda.durable_function.* to aws.durable.*

### DIFF
--- a/datadog_lambda/durable.py
+++ b/datadog_lambda/durable.py
@@ -47,9 +47,9 @@ def extract_durable_function_tags(event):
     operations = event.get("InitialExecutionState", {}).get("Operations", [])
     is_first_invocation = len(operations) == 1
     return {
-        "aws_lambda.durable_function.execution_name": execution_name,
-        "aws_lambda.durable_function.execution_id": execution_id,
-        "aws_lambda.durable_function.first_invocation": str(
+        "aws.durable.execution_name": execution_name,
+        "aws.durable.execution_id": execution_id,
+        "aws.durable.first_invocation": str(
             is_first_invocation
         ).lower(),
     }

--- a/datadog_lambda/durable.py
+++ b/datadog_lambda/durable.py
@@ -49,9 +49,7 @@ def extract_durable_function_tags(event):
     return {
         "aws.durable.execution_name": execution_name,
         "aws.durable.execution_id": execution_id,
-        "aws.durable.first_invocation": str(
-            is_first_invocation
-        ).lower(),
+        "aws.durable.first_invocation": str(is_first_invocation).lower(),
     }
 
 

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -346,7 +346,7 @@ class _LambdaDecorator(object):
                 durable_status = extract_durable_execution_status(self.response, event)
                 if durable_status:
                     self.span.set_tag(
-                        "aws_lambda.durable_function.execution_status",
+                        "aws.durable.execution_status",
                         durable_status,
                     )
 

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -57,9 +57,9 @@ class TestExtractDurableFunctionTags(unittest.TestCase):
         self.assertEqual(
             result,
             {
-                "aws_lambda.durable_function.execution_name": "my-execution",
-                "aws_lambda.durable_function.execution_id": "550e8400-e29b-41d4-a716-446655440004",
-                "aws_lambda.durable_function.first_invocation": "true",
+                "aws.durable.execution_name": "my-execution",
+                "aws.durable.execution_id": "550e8400-e29b-41d4-a716-446655440004",
+                "aws.durable.first_invocation": "true",
             },
         )
 
@@ -79,9 +79,9 @@ class TestExtractDurableFunctionTags(unittest.TestCase):
         self.assertEqual(
             result,
             {
-                "aws_lambda.durable_function.execution_name": "my-execution",
-                "aws_lambda.durable_function.execution_id": "550e8400-e29b-41d4-a716-446655440004",
-                "aws_lambda.durable_function.first_invocation": "false",
+                "aws.durable.execution_name": "my-execution",
+                "aws.durable.execution_id": "550e8400-e29b-41d4-a716-446655440004",
+                "aws.durable.first_invocation": "false",
             },
         )
 


### PR DESCRIPTION
## Summary
- Renames the four durable-execution span tags set on the `aws.lambda` span:
  - `aws_lambda.durable_function.execution_name` → `aws.durable.execution_name`
  - `aws_lambda.durable_function.execution_id` → `aws.durable.execution_id`
  - `aws_lambda.durable_function.first_invocation` → `aws.durable.first_invocation`
  - `aws_lambda.durable_function.execution_status` → `aws.durable.execution_status`
- Updates `tests/test_durable.py` assertions to match.

## Test plan
- [ ] `pytest tests/test_durable.py`