### PR TITLE
remove import of private ddtrace constant

### DIFF
--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -16,10 +16,11 @@ from datadog_lambda.config import config
 from datadog_lambda.metric import lambda_metric
 from datadog_lambda.thread_stats_writer import ThreadStatsWriter
 from ddtrace.trace import Span, tracer
-from ddtrace.internal.constants import MAX_UINT_64BITS
+
 
 from tests.utils import get_mock_context, reset_xray_connection
 
+MAX_UINT_64BITS = (1 << 64) - 1
 
 class TestDatadogLambdaWrapper(unittest.TestCase):
     def setUp(self):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -22,6 +22,7 @@ from tests.utils import get_mock_context, reset_xray_connection
 
 MAX_UINT_64BITS = (1 << 64) - 1
 
+
 class TestDatadogLambdaWrapper(unittest.TestCase):
     def setUp(self):
         # Force @datadog_lambda_wrapper to always create a real


### PR DESCRIPTION
This change removes an import of private ddtrace functionality by copypasting it. This is appropriate because it's a trivial and commonplace constant definition that is not specific to the ddtrace public API.