### PR TITLE
fix: activate venv in publish_pypi.sh

### DIFF
--- a/ci/publish_pypi.sh
+++ b/ci/publish_pypi.sh
@@ -28,4 +28,5 @@ if [ -d "dist" ]; then
 fi
 
 # Publish to pypi
+source venv/bin/activate
 poetry publish --build --username __token__ --password $PYPI_TOKEN


### PR DESCRIPTION
## Summary
- Fix poetry: [command not found error](https://gitlab.ddbuild.io/DataDog/datadog-lambda-python/-/jobs/1854916021/raw) in the publish-pypi-package CI job 
- The before_script runs setup_python_env.sh which installs poetry inside a virtualenv, but since it executes as a subshell the venv activation doesn't persist into the script: phase
- Add source venv/bin/activate before calling poetry, matching the pattern used by the lint and unit-test jobs



