### PR TITLE
Guard against non-dict Payload in is_step_function_event

### DIFF
--- a/datadog_lambda/trigger.py
+++ b/datadog_lambda/trigger.py
@@ -461,6 +461,8 @@ def is_step_function_event(event):
     The actual event must contain "Execution", "StateMachine", and "State" fields.
     """
     event = event.get("Payload", event)
+    if not isinstance(event, dict):
+        return False
 
     # JSONPath style
     if "Execution" in event and "StateMachine" in event and "State" in event:

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -757,3 +757,7 @@ class IsStepFunctionEvent(unittest.TestCase):
             }
         }
         self.assertFalse(is_step_function_event(event))
+
+    def test_is_step_function_event_payload_not_dict(self):
+        event = {"Payload": "This is a string, not a dict"}
+        self.assertFalse(is_step_function_event(event))


### PR DESCRIPTION
Fixes https://github.com/DataDog/datadog-lambda-python/issues/845

## Summary
- `is_step_function_event` unwrapped `event.get(\"Payload\", event)` and then checked for dict keys without verifying the unwrapped value was actually a dict, which broke when `Payload` was a string.
- Add an `isinstance(event, dict)` guard that returns `False` early when the payload isn't a dict.

## Test plan
- [x] Added `test_is_step_function_event_payload_not_dict` in `tests/test_trigger.py`
- [x] `python -m pytest tests/test_trigger.py -k IsStepFunctionEvent` passes